### PR TITLE
화원가입 완료 후에도 이용약관동의 페이지로 이동하는문제

### DIFF
--- a/lib/models/user_info.dart
+++ b/lib/models/user_info.dart
@@ -77,8 +77,7 @@ class UserInfo {
 
   /// 온보딩이 필요한지 확인
   bool get needsOnboarding {
-    return isFirstLogin == true || 
-           isRequiredTermsAgreed != true ||
+    return isRequiredTermsAgreed != true ||
            isMemberLocationSaved != true ||
            isItemCategorySaved != true;
   }

--- a/lib/screens/onboarding/term_agreement_step.dart
+++ b/lib/screens/onboarding/term_agreement_step.dart
@@ -79,20 +79,21 @@ class _TermAgreementStepState extends State<TermAgreementStep> {
       // 마케팅 동의 여부 확인
       final isMarketingAgreed = _termsChecked[TermsType.marketing] ?? false;
 
-      // 백엔드에 약관 동의 정보 전송
-      final success = await _memberApi.saveTermsAgreement(
+      // 약관 동의 정보 전송
+      final isSuccess = await _memberApi.saveTermsAgreement(
         isMarketingInfoAgreed: isMarketingAgreed,
       );
 
-      if (success) {
+      if (isSuccess) {
         // 사용자 정보 업데이트
         final userInfo = UserInfo();
-        await userInfo.getUserInfo(); // 최신 정보 재로드
+        // 최신 회원 정보 재로드
+        await userInfo.getUserInfo();
 
         // 다음 단계로 이동
         widget.onNext();
       } else {
-        // 실패 시 스낵바 표시
+        // 실패 시
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(


### PR DESCRIPTION
#128 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 온보딩 필요 여부 판단 시 첫 로그인 상태를 더 이상 고려하지 않도록 변경되었습니다. 이제 필수 약관 동의, 멤버 위치 저장, 아이템 카테고리 저장 여부만 확인합니다.
- **스타일**
  - 약관 동의 단계에서 일부 변수명과 주석이 더 명확하게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->