### PR TITLE
홈 탭 첫 진입블러 상태에서 세로 스와이프 차단 및 내 물건 등록 CTA 오버레이 고정안되는 문제

### DIFF
--- a/lib/screens/home_tab_screen.dart
+++ b/lib/screens/home_tab_screen.dart
@@ -197,7 +197,7 @@ class _HomeTabScreenState extends State<HomeTabScreen> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: List.generate(
             _coachMarkImages.length,
-            (index) {
+                (index) {
               final isCurrentPage = index == currentPage;
               return GestureDetector(
                 onTap: () {
@@ -412,9 +412,14 @@ class _HomeTabScreenState extends State<HomeTabScreen> {
             child: PageView.builder(
               scrollDirection: Axis.vertical,
               controller: _pageController,
+              // 블러가 활성화된 경우 스와이프(스크롤) 동작을 비활성화해 첫 화면 고정
+              physics: _isBlurShown
+                  ? const NeverScrollableScrollPhysics()
+                  : const PageScrollPhysics(),
               itemCount: _feedItems.length + (_hasMoreItems ? 1 : 0),
               onPageChanged: (index) {
-                if (index < _feedItems.length) {
+                // 블러가 켜져 있으면 페이지 변경 자체가 발생하지 않으므로, 여기서는 블러 OFF 상태만 처리
+                if (!_isBlurShown && index < _feedItems.length) {
                   setState(() {
                     _currentFeedIndex = index;
                   });


### PR DESCRIPTION
- #162 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 블러 오버레이가 활성화된 경우 메인 피드에서 세로 스와이프가 비활성화되어, 의도치 않은 페이지 이동이 방지됩니다.
  * 블러가 활성화된 상태에서는 피드 인덱스가 변경되지 않도록 개선되었습니다.

* **스타일**
  * 코치마크 페이지 인디케이터의 들여쓰기가 소폭 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->