### PR TITLE
아이폰에서 왼쪽 사이드 스와이프 뒤로가기 제스처 미작동 : feat : 화면 전환 MaterialPageRoute 로 수정 …

### DIFF
--- a/lib/widgets/home_feed_item_widget.dart
+++ b/lib/widgets/home_feed_item_widget.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
@@ -120,23 +121,17 @@ class _HomeFeedItemWidgetState extends State<HomeFeedItemWidget> {
                     child: GestureDetector(
                       onTap: () async {
                         final resultIndex = await Navigator.push(
-                            context,
-                            PageRouteBuilder(
-                              transitionDuration:
-                                  const Duration(milliseconds: 1000),
-                              pageBuilder: (_, __, ___) =>
-                                  ItemDetailDescriptionScreen(
-                                itemId: widget.item.itemUuid ?? '',
-                                imageSize: Size(
-                                  screenWidth,
-                                  screenWidth,
-                                ),
-                                currentImageIndex: index,
-                                heroTag: 'itemImage_${widget.item.id}',
-                                homeFeedItem: widget.item,
-                              ),
-                            ));
-
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => ItemDetailDescriptionScreen(
+                              itemId: widget.item.itemUuid ?? '',
+                              imageSize: Size(screenWidth, screenWidth),
+                              currentImageIndex: index,
+                              heroTag: 'itemImage_${widget.item.id}_$index',
+                              homeFeedItem: widget.item,
+                            ),
+                          ),
+                        );
                         if (resultIndex != null && resultIndex is int) {
                           setState(() {
                             _currentImageIndex = resultIndex;
@@ -145,7 +140,7 @@ class _HomeFeedItemWidgetState extends State<HomeFeedItemWidget> {
                         }
                       },
                       child: Hero(
-                        tag: 'itemImage_${widget.item.id}',
+                        tag: 'itemImage_${widget.item.id}_$index',
                         child: ClipRRect(
                           borderRadius: BorderRadius.only(
                               topLeft: Radius.circular(4.r),
@@ -325,8 +320,8 @@ class _HomeFeedItemWidgetState extends State<HomeFeedItemWidget> {
                           enabled: widget.showBlur,
                           child: UserProfileCircularAvatar(
                             avatarSize: const Size(50, 50),
-                            profileUrl: widget.item.profileUrl.isNotEmpty 
-                                ? widget.item.profileUrl 
+                            profileUrl: widget.item.profileUrl.isNotEmpty
+                                ? widget.item.profileUrl
                                 : null,
                           ),
                         ),

--- a/lib/widgets/home_feed_item_widget.dart
+++ b/lib/widgets/home_feed_item_widget.dart
@@ -1,6 +1,5 @@
 import 'dart:ui';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
@@ -127,7 +126,8 @@ class _HomeFeedItemWidgetState extends State<HomeFeedItemWidget> {
                               itemId: widget.item.itemUuid ?? '',
                               imageSize: Size(screenWidth, screenWidth),
                               currentImageIndex: index,
-                              heroTag: 'itemImage_${widget.item.id}_$index',
+                              heroTag:
+                                  'itemImage_${widget.item.itemUuid ?? widget.item.id}_$index',
                               homeFeedItem: widget.item,
                             ),
                           ),
@@ -140,7 +140,8 @@ class _HomeFeedItemWidgetState extends State<HomeFeedItemWidget> {
                         }
                       },
                       child: Hero(
-                        tag: 'itemImage_${widget.item.id}_$index',
+                        tag:
+                            'itemImage_${widget.item.itemUuid ?? widget.item.id}_$index',
                         child: ClipRRect(
                           borderRadius: BorderRadius.only(
                               topLeft: Radius.circular(4.r),


### PR DESCRIPTION
- https://github.com/TEAM-ROMROM/RomRom-FE/issues/235
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 여러 이미지를 가진 항목에서 히어로 애니메이션이 겹치거나 오동작하던 문제를 해결해 안정적으로 동작하도록 개선했습니다.

- **리팩토링**
  - 화면 전환을 1초 커스텀 애니메이션 대신 기본 전환으로 통일해 내비게이션 경험을 일관되게 조정했습니다.
  - 사소한 코드 포맷 정리를 수행해 가독성을 향상했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->