### PR TITLE
인디케이터 색깔 및 간격 변경 : feat : 물품사진 인디케이터 색상 white에서 primaryYellow로 변경, 간격…

### DIFF
--- a/lib/widgets/home_feed_item_widget.dart
+++ b/lib/widgets/home_feed_item_widget.dart
@@ -191,11 +191,11 @@ class _HomeFeedItemWidgetState extends State<HomeFeedItemWidget> {
                   (index) => Container(
                     width: 6.w,
                     height: 6.w,
-                    margin: EdgeInsets.symmetric(horizontal: 4.w),
+                    margin: EdgeInsets.symmetric(horizontal: 2.w),
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
                       color: _currentImageIndex == index
-                          ? Colors.white
+                          ? AppColors.primaryYellow
                           : AppColors.opacity50White,
                     ),
                   ),


### PR DESCRIPTION
#251 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 홈 피드 아이템의 하단 이미지 인디케이터 UI를 개선했습니다.
  - 점 간격을 축소해 가독성을 높였습니다(수평 마진 4→2).
  - 현재 이미지 표시 점 색상을 흰색에서 브랜드 옐로로 변경해 활성 상태를 더 명확히 했습니다.
  - 비활성 점은 기존의 반투명 흰색을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->