### PR TITLE
20250826 #233 버그 물품상세 좋아요 클릭 시 네이버 지도가 다시 리프레시되는 문제

### DIFF
--- a/lib/screens/item_detail_description_screen.dart
+++ b/lib/screens/item_detail_description_screen.dart
@@ -513,7 +513,7 @@ class _ItemDetailDescriptionScreenState
                       /// 거래 희망 장소
                       Container(
                         width: double.infinity,
-                        margin: EdgeInsets.symmetric(vertical: 16.h),
+                        margin: EdgeInsets.only(top: 16.h, bottom: 61.h),
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
@@ -547,6 +547,7 @@ class _ItemDetailDescriptionScreenState
                                 borderRadius: BorderRadius.circular(4.r),
                                 child: NaverMap(
                                   key: ValueKey('detail_map_${widget.itemId}'),
+                                  forceGesture: true,
                                   options: NaverMapViewOptions(
                                     initialCameraPosition: NCameraPosition(
                                       target: NLatLng(
@@ -555,6 +556,8 @@ class _ItemDetailDescriptionScreenState
                                       ),
                                       zoom: 15,
                                     ),
+                                    scrollGesturesEnable: true, // 지도 이동
+                                    zoomGesturesEnable: true, // 확대/축소
                                   ),
                                   onMapReady: (controller) {
                                     if (item?.latitude != null &&

--- a/lib/screens/item_detail_description_screen.dart
+++ b/lib/screens/item_detail_description_screen.dart
@@ -71,6 +71,8 @@ class _ItemDetailDescriptionScreenState
     super.initState();
     currentIndexVN = ValueNotifier<int>(widget.currentImageIndex);
     pageController = PageController(initialPage: widget.currentImageIndex);
+    isLikedVN = ValueNotifier<bool>(false);
+    likeCountVN = ValueNotifier<int>(0);
     _loadItemDetail();
   }
 
@@ -91,8 +93,8 @@ class _ItemDetailDescriptionScreenState
         item = response.item;
         itemImages = response.itemImages;
         itemCustomTags = response.itemCustomTags;
-        isLikedVN = ValueNotifier<bool>(response.likeStatus == 'LIKE');
-        likeCountVN = ValueNotifier<int>(response.likeCount ?? 0);
+        isLikedVN.value = (response.likeStatus == 'LIKE');
+        likeCountVN.value = response.likeCount ?? 0;
 
         imageUrls = itemImages
                 ?.map((img) => img.imageUrl ?? '')

--- a/lib/screens/item_detail_description_screen.dart
+++ b/lib/screens/item_detail_description_screen.dart
@@ -50,6 +50,8 @@ class _ItemDetailDescriptionScreenState
     extends State<ItemDetailDescriptionScreen> {
   late PageController pageController;
   late final ValueNotifier<int> currentIndexVN;
+  late final ValueNotifier<bool> isLikedVN;
+  late final ValueNotifier<int> likeCountVN;
 
   bool isLoading = true;
   bool hasError = false;
@@ -58,8 +60,6 @@ class _ItemDetailDescriptionScreenState
   Item? item;
   List<ItemImage>? itemImages;
   List<String>? itemCustomTags;
-  String? likeStatus;
-  int? likeCount;
   String locationName = '위치 정보 로딩 중...';
   String memberLocationName = '위치 정보 로딩 중...';
 
@@ -90,8 +90,8 @@ class _ItemDetailDescriptionScreenState
         item = response.item;
         itemImages = response.itemImages;
         itemCustomTags = response.itemCustomTags;
-        likeStatus = response.likeStatus;
-        likeCount = response.likeCount;
+        isLikedVN = ValueNotifier<bool>(response.likeStatus == 'LIKE');
+        likeCountVN = ValueNotifier<int>(response.likeCount ?? 0);
 
         imageUrls = itemImages
                 ?.map((img) => img.imageUrl ?? '')
@@ -261,7 +261,6 @@ class _ItemDetailDescriptionScreenState
     }
 
     String formattedPrice = formatPrice(item!.price ?? 0);
-    bool isLiked = likeStatus == 'LIKE';
 
     return Scaffold(
       body: Stack(
@@ -381,18 +380,24 @@ class _ItemDetailDescriptionScreenState
                                 ),
                                 child: Row(
                                   children: [
-                                    SvgPicture.asset(
-                                      isLiked
-                                          ? 'assets/images/like-heart-icon.svg'
-                                          : 'assets/images/dislike-heart-icon.svg',
-                                      width: 16.w,
-                                      height: 16.h,
-                                    ),
+                                    ValueListenableBuilder<bool>(
+                                        valueListenable: isLikedVN,
+                                        builder: (_, liked, __) {
+                                          return SvgPicture.asset(
+                                            liked
+                                                ? 'assets/images/like-heart-icon.svg'
+                                                : 'assets/images/dislike-heart-icon.svg',
+                                            width: 16.w,
+                                            height: 16.h,
+                                          );
+                                        }),
                                     SizedBox(width: 4.w),
-                                    Text(
-                                      (likeCount ?? 0).toString(),
-                                      style: CustomTextStyles.p2,
-                                    ),
+                                    ValueListenableBuilder<int>(
+                                        valueListenable: likeCountVN,
+                                        builder: (_, likeCount, __) {
+                                          return Text(likeCount.toString(),
+                                              style: CustomTextStyles.p2);
+                                        }),
                                   ],
                                 ),
                               ),
@@ -631,19 +636,26 @@ class _ItemDetailDescriptionScreenState
   Future<void> _toggleLike() async {
     if (item?.itemId == null) return;
 
+    final prevLiked = isLikedVN.value;
+    final prevCount = likeCountVN.value;
+
+    // 1) 빠른 UI 업데이트
+    isLikedVN.value = !prevLiked;
+    likeCountVN.value = prevLiked ? (prevCount - 1) : (prevCount + 1);
+
     try {
-      final ItemApi itemApi = ItemApi();
-      final ItemRequest request = ItemRequest(itemId: item!.itemId);
-      final ItemResponse response = await itemApi.postLike(request);
+      final itemApi = ItemApi();
+      final req = ItemRequest(itemId: item!.itemId);
+      final res = await itemApi.postLike(req);
 
-      if (!mounted) return;
-
-      setState(() {
-        likeStatus = response.likeStatus;
-        likeCount = response.likeCount;
-      });
+      // 2) 서버 결과로 보정(서버-클라 불일치 대비)
+      isLikedVN.value = (res.likeStatus == 'LIKE');
+      likeCountVN.value = res.likeCount ?? likeCountVN.value;
     } catch (e) {
-      debugPrint('좋아요 상태 변경 실패: $e');
+      debugPrint('좋아요 실패: $e');
+      // 3) 실패 롤백
+      isLikedVN.value = prevLiked;
+      likeCountVN.value = prevCount;
     }
   }
 }

--- a/lib/widgets/home_feed_item_widget.dart
+++ b/lib/widgets/home_feed_item_widget.dart
@@ -305,74 +305,76 @@ class _HomeFeedItemWidgetState extends State<HomeFeedItemWidget> {
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  BlurWrapper(
-                    enabled: widget.showBlur,
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        // 물품 이름
-                        Text(
-                          widget.item.name.trim(),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: CustomTextStyles.h3
-                              .copyWith(fontWeight: FontWeight.w600),
-                        ),
+                  Expanded(
+                    child: BlurWrapper(
+                      enabled: widget.showBlur,
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          // 물품 이름
+                          Text(
+                            widget.item.name.trim(),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: CustomTextStyles.h3
+                                .copyWith(fontWeight: FontWeight.w600),
+                          ),
 
-                        SizedBox(height: 8.h),
+                          SizedBox(height: 8.h),
 
-                        // 위치 및 날짜 정보
-                        Row(
-                          children: [
-                            Icon(AppIcons.location,
-                                color: AppColors.opacity80White, size: 13.sp),
-                            SizedBox(width: 4.w),
-                            Text(
-                              '${widget.item.location} • $formattedDate',
-                              style: CustomTextStyles.p3
-                                  .copyWith(fontWeight: FontWeight.w500),
-                            ),
-                          ],
-                        ),
-
-                        SizedBox(height: 12.h),
-
-                        Row(
-                          children: [
-                            // 사용감 태그 - ItemDetail과 동일한 위젯 사용
-                            ItemDetailConditionTag(
-                              condition: widget.item.itemCondition.name,
-                            ),
-                            SizedBox(width: 4.w),
-                            // 거래 방식 태그들 - ItemDetail과 동일한 위젯 사용
-                            ...widget.item.transactionTypes.map(
-                              (type) => ItemDetailTradeOptionTag(
-                                option: type.name,
+                          // 위치 및 날짜 정보
+                          Row(
+                            children: [
+                              Icon(AppIcons.location,
+                                  color: AppColors.opacity80White, size: 13.sp),
+                              SizedBox(width: 4.w),
+                              Text(
+                                '${widget.item.location} • $formattedDate',
+                                style: CustomTextStyles.p3
+                                    .copyWith(fontWeight: FontWeight.w500),
                               ),
-                            ),
-                          ],
-                        ),
+                            ],
+                          ),
 
-                        SizedBox(height: 10.h),
+                          SizedBox(height: 12.h),
 
-                        Row(
-                          children: [
-                            // 물품 가격
-                            Text(
-                              "$formattedPrice원",
-                              style: CustomTextStyles.p1
-                                  .copyWith(fontWeight: FontWeight.w600),
-                            ),
+                          Row(
+                            children: [
+                              // 사용감 태그 - ItemDetail과 동일한 위젯 사용
+                              ItemDetailConditionTag(
+                                condition: widget.item.itemCondition.name,
+                              ),
+                              SizedBox(width: 4.w),
+                              // 거래 방식 태그들 - ItemDetail과 동일한 위젯 사용
+                              ...widget.item.transactionTypes.map(
+                                (type) => ItemDetailTradeOptionTag(
+                                  option: type.name,
+                                ),
+                              ),
+                            ],
+                          ),
 
-                            SizedBox(width: 8.w),
+                          SizedBox(height: 10.h),
 
-                            _useAiPrice
-                                ? const AiBadgeWidget()
-                                : const SizedBox(),
-                          ],
-                        ),
-                      ],
+                          Row(
+                            children: [
+                              // 물품 가격
+                              Text(
+                                "$formattedPrice원",
+                                style: CustomTextStyles.p1
+                                    .copyWith(fontWeight: FontWeight.w600),
+                              ),
+
+                              SizedBox(width: 8.w),
+
+                              _useAiPrice
+                                  ? const AiBadgeWidget()
+                                  : const SizedBox(),
+                            ],
+                          ),
+                        ],
+                      ),
                     ),
                   ),
 


### PR DESCRIPTION
#233  #234 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 좋아요가 즉시 반영되는 낙관적 UI로 변경되어 반응성이 개선되었고, 서버 실패 시 자동으로 이전 상태로 복구됩니다.
  - 좋아요 아이콘과 카운트가 실시간으로 업데이트되어 UI가 즉시 반응합니다.
- Bug Fixes
  - 비어 있는 이미지 URL을 필터링해 이미지 로딩 오류를 완화했습니다.
- Style
  - 거래 희망 장소 영역의 상/하 여백을 조정해 레이아웃을 안정화했습니다.
  - 홈 피드 아이템 하단 정보의 너비 배분을 개선해 왼쪽 정보 영역이 가용 공간을 유연하게 차지합니다.
- Improvements
  - 지도에서 스크롤 및 줌 제스처가 활성화되어 탐색이 쉬워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->