### PR TITLE
마지막_물품_제외_보낸_요청_누락 : feat : 내 모든 물품에 대해 보낸 요청 표시 https://github.com/T…

### DIFF
--- a/lib/screens/request_management_tab_screen.dart
+++ b/lib/screens/request_management_tab_screen.dart
@@ -86,13 +86,12 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
       duration: const Duration(milliseconds: 300),
       vsync: this,
     );
-    _toggleAnimation = Tween<double>(
-      begin: 0.0,
-      end: 1.0,
-    ).animate(CurvedAnimation(
-      parent: _toggleAnimationController,
-      curve: Curves.easeInOut,
-    ));
+    _toggleAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _toggleAnimationController,
+        curve: Curves.easeInOut,
+      ),
+    );
 
     _loadInitialItems();
   }
@@ -106,16 +105,19 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
 
     try {
       final itemApi = ItemApi();
-      final response = await itemApi.getMyItems(ItemRequest(
-        pageNumber: _currentPage,
-        pageSize: _pageSize,
-        itemStatus: ItemStatus.available.serverName,
-      ));
+      final response = await itemApi.getMyItems(
+        ItemRequest(
+          pageNumber: _currentPage,
+          pageSize: _pageSize,
+          itemStatus: ItemStatus.available.serverName,
+        ),
+      );
 
       if (!mounted) return;
 
       final itemCard = await _convertToRequestManagementItemCard(
-          response.itemPage?.content ?? []);
+        response.itemPage?.content ?? [],
+      );
 
       setState(() {
         _itemCards
@@ -131,9 +133,9 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
       if (!mounted) return;
 
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('피드 로딩 실패: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('피드 로딩 실패: $e')));
     }
     setState(() {
       _isLoading = false;
@@ -142,14 +144,16 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
 
   /// ItemDetail을 RequestManagementItemCard로 변환
   Future<List<RequestManagementItemCard>> _convertToRequestManagementItemCard(
-      List<Item> details) async {
+    List<Item> details,
+  ) async {
     final itemCards = <RequestManagementItemCard>[];
 
     for (int index = 0; index < details.length; index++) {
       final d = details[index];
 
-      String category =
-          ItemCategories.fromServerName(d.itemCategory ?? '기타').label;
+      String category = ItemCategories.fromServerName(
+        d.itemCategory ?? '기타',
+      ).label;
 
       final itemCard = RequestManagementItemCard(
         itemId: d.itemId ?? '',
@@ -171,7 +175,7 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
 
   /// 현재 선택된 카드의 받은 요청 목록 로드
   Future<List<TradeRequestHistory>>
-      _loadReceivedRequestsForCurrentCard() async {
+  _loadReceivedRequestsForCurrentCard() async {
     if (!mounted) return const [];
 
     setState(() => _isLoading = true);
@@ -188,7 +192,10 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
 
       final paged = await api.getReceivedTradeRequests(
         TradeRequest(
-            takeItemId: currentCard.itemId, pageNumber: 0, pageSize: 10),
+          takeItemId: currentCard.itemId,
+          pageNumber: 0,
+          pageSize: 10,
+        ),
       );
 
       final list = paged.content;
@@ -198,10 +205,12 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
       }
 
       // 주소 캐시를 모두 채워둠
-      await Future.wait(list.map((r) async {
-        await r.takeItem.resolveAndCacheAddress();
-        await r.giveItem.resolveAndCacheAddress();
-      }));
+      await Future.wait(
+        list.map((r) async {
+          await r.takeItem.resolveAndCacheAddress();
+          await r.giveItem.resolveAndCacheAddress();
+        }),
+      );
 
       if (mounted) {
         setState(() {
@@ -238,30 +247,43 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
       final api = TradeApi();
 
       // 모든 카드에 대해 병렬로 요청을 보내고 결과를 합칩니다.
-      final pagedResults = await Future.wait<PagedTradeRequestHistory?>(_itemCards.map((card) async{
-        try {
-          return await api.getSentTradeRequests(
-            TradeRequest(giveItemId: card.itemId),
-          );
-        } catch (error, stackTrace) {
-          debugPrint('보낸 요청 로드 실패 for itemId ${card.itemId}: $error\n$stackTrace');
-          return null;
-        }
-      },),
-      eagerError: false,
+      final pagedResults = await Future.wait<PagedTradeRequestHistory?>(
+        _itemCards.map((card) async {
+          try {
+            return await api.getSentTradeRequests(
+              TradeRequest(giveItemId: card.itemId),
+            );
+          } catch (error, stackTrace) {
+            debugPrint(
+              '보낸 요청 로드 실패 for itemId ${card.itemId}: $error\n$stackTrace',
+            );
+            return null;
+          }
+        }),
+        eagerError: false,
       );
-
 
       final allRequests = <TradeRequestHistory>[];
       for (final paged in pagedResults) {
-        if(paged == null) continue;
+        if (paged == null) continue;
         final list = paged.content;
         if (list.isNotEmpty) {
           // 각 요청의 take/give 아이템 주소 캐시 채우기
-          await Future.wait(list.map((r) async {
-            await r.takeItem.resolveAndCacheAddress();
-            await r.giveItem.resolveAndCacheAddress();
-          }));
+          await Future.wait(
+            list.map((r) async {
+              try {
+                await r.takeItem.resolveAndCacheAddress();
+              } catch (e) {
+                debugPrint('takeItem 주소 해석 실패: $e');
+              }
+              try {
+                await r.giveItem.resolveAndCacheAddress();
+              } catch (e) {
+                debugPrint('giveItem 주소 해석 실패: $e');
+              }
+            }),
+            eagerError: false,
+          );
           allRequests.addAll(list);
         }
       }
@@ -351,9 +373,12 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
                 createdDate: takeItem.createdDate!,
                 tradeOptions: takeItem.itemTradeOptions != null
                     ? takeItem.itemTradeOptions!
-                        .map((s) => ItemTradeOption.values
-                            .firstWhere((e) => e.serverName == s))
-                        .toList()
+                          .map(
+                            (s) => ItemTradeOption.values.firstWhere(
+                              (e) => e.serverName == s,
+                            ),
+                          )
+                          .toList()
                     : [],
                 tradeStatus: request.tradeStatus != null
                     ? TradeStatus.values.firstWhere(
@@ -383,8 +408,9 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
                   }
                   if (mounted) {
                     setState(() {
-                      _sentRequests
-                          .removeAt(index); // Use the correct index here
+                      _sentRequests.removeAt(
+                        index,
+                      ); // Use the correct index here
                     });
                   }
                 },
@@ -454,8 +480,9 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
   @override
   Widget build(BuildContext context) {
     return AnnotatedRegion<SystemUiOverlayStyle>(
-      value: SystemUiOverlayStyle.light
-          .copyWith(statusBarColor: AppColors.transparent),
+      value: SystemUiOverlayStyle.light.copyWith(
+        statusBarColor: AppColors.transparent,
+      ),
       child: Scaffold(
         backgroundColor: AppColors.primaryBlack,
         extendBodyBehindAppBar: true,
@@ -484,8 +511,9 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
                           leftText: '받은 요청',
                           rightText: '보낸 요청',
                         ),
-                        statusBarHeight:
-                            MediaQuery.of(context).padding.top, // ★ 꼭 전달
+                        statusBarHeight: MediaQuery.of(
+                          context,
+                        ).padding.top, // ★ 꼭 전달
                         toolbarHeight: 58.h,
                         toggleHeight: 70.h,
                         expandedExtra: 32.h, // 큰 제목/여백
@@ -743,8 +771,10 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
                         context.navigateTo(
                           screen: ItemDetailDescriptionScreen(
                             itemId: giveItem.itemId!, // 요청 받은 카드로 이동
-                            imageSize:
-                                Size(MediaQuery.of(context).size.width, 400.h),
+                            imageSize: Size(
+                              MediaQuery.of(context).size.width,
+                              400.h,
+                            ),
                             currentImageIndex: 0,
                             heroTag:
                                 'itemImage_${request.giveItem.itemId!}_0', // ← 인덱스 포함
@@ -763,9 +793,12 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
                         isNew: request.isNew ?? false,
                         tradeOptions: giveItem.itemTradeOptions != null
                             ? giveItem.itemTradeOptions!
-                                .map((s) => ItemTradeOption.values
-                                    .firstWhere((e) => e.serverName == s))
-                                .toList()
+                                  .map(
+                                    (s) => ItemTradeOption.values.firstWhere(
+                                      (e) => e.serverName == s,
+                                    ),
+                                  )
+                                  .toList()
                             : [],
                         tradeStatus: request.tradeStatus != null
                             ? TradeStatus.values.firstWhere(
@@ -775,18 +808,22 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
                             : TradeStatus.chatting,
                         onMenuTap: () async {
                           try {
-                            await TradeApi().cancelTradeRequest(TradeRequest(
-                              tradeRequestHistoryId:
-                                  request.tradeRequestHistoryId,
-                            ));
+                            await TradeApi().cancelTradeRequest(
+                              TradeRequest(
+                                tradeRequestHistoryId:
+                                    request.tradeRequestHistoryId,
+                              ),
+                            );
                           } catch (e) {
                             debugPrint('요청 취소 실패: $e');
                           }
                           if (mounted) {
                             setState(() {
-                              _receivedRequests.removeWhere((e) =>
-                                  e.tradeRequestHistoryId ==
-                                  request.tradeRequestHistoryId);
+                              _receivedRequests.removeWhere(
+                                (e) =>
+                                    e.tradeRequestHistoryId ==
+                                    request.tradeRequestHistoryId,
+                              );
                             });
                           }
                         },
@@ -801,6 +838,7 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
                   ],
                 );
               }),
-            ));
+            ),
+          );
   }
 }


### PR DESCRIPTION
#338 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 개선**
  * 모든 카드의 보낸 요청을 병렬로 조회해 로딩 속도 향상.
  * 요청 항목의 주소 정보를 병렬로 미리 캐시해 주소 표시가 더 안정적.

* **버그 수정**
  * 현재 선택된 카드 의존성 제거로 모든 카드의 요청이 정상 조회됨.
  * 카드별 개별 오류 처리로 일부 실패 시에도 전체 동작이 중단되지 않음.
  * 보낸 요청 상태 갱신 방식 개선으로 목록 일관성 향상.

* **스타일·문구**
  * 오류 메시지 및 UI 구성의 문구·포맷이 일관되게 정리됨.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->