### PR TITLE
채팅 기록이 저장되지 않는 버그 : fix : chat websocket 통신 시 메시지 전송 구조에서 createdAt 삭…

### DIFF
--- a/lib/services/chat_websocket_service.dart
+++ b/lib/services/chat_websocket_service.dart
@@ -228,15 +228,10 @@ class ChatWebSocketService {
       throw Exception('STOMP not connected');
     }
 
-    final now = DateTime.now()
-        .toUtc()
-        .millisecondsSinceEpoch; // epoch ms (UTC 권장)
-
     final payload = jsonEncode({
       'chatRoomId': chatRoomId,
       'content': content,
       'type': type.toString().split('.').last.toUpperCase(),
-      'clientSentAt': now,
     });
 
     debugPrint('[WebSocket] Sending message to /app/chat.send');


### PR DESCRIPTION
#441 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 채팅 메시지 전송 시 불필요한 타임스탬프 제거로 메시지 처리 개선

---

**변경 사항:** 채팅 기능의 메시지 페이로드에서 내부 타임스탬프 필드를 제거하여 메시지 전송 동작을 최적화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->