### PR TITLE
20260316 #667 알림 페이지 하단 UI 버그

### DIFF
--- a/lib/screens/notification_screen.dart
+++ b/lib/screens/notification_screen.dart
@@ -268,9 +268,17 @@ class _NotificationScreenState extends State<NotificationScreen> with SingleTick
       debugPrint('알림 읽음 처리 실패: $e');
     }
     if (!mounted) return;
-    await RomRomDeepLinkRouter.open(context, notification.deepLink, notificationType: notification.type);
-    if (mounted) {
-      await _loadNotifications();
+    try {
+      await RomRomDeepLinkRouter.open(context, notification.deepLink, notificationType: notification.type);
+    } catch (e) {
+      debugPrint('딥링크 이동 실패: $e');
+      if (mounted) {
+        CommonSnackBar.show(context: context, message: '화면 이동에 실패했습니다.', type: SnackBarType.error);
+      }
+    } finally {
+      if (mounted) {
+        await _loadNotifications();
+      }
     }
   }
 

--- a/lib/services/apis/notification_api.dart
+++ b/lib/services/apis/notification_api.dart
@@ -41,7 +41,7 @@ class NotificationApi {
     const String url = '${AppUrls.baseUrl}/api/notification/update/read';
 
     final Map<String, dynamic> fields = {
-      'notificationHistoryId': notificationHistoryId, // 읽음 처리할 알림 ID 리스트 (빈 리스트는 전체 읽음 처리 의미)
+      'notificationHistoryId': notificationHistoryId, // 읽음 처리할 알림 ID(단건)
     };
 
     await ApiClient.sendMultipartRequest(


### PR DESCRIPTION
#667 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 알림을 탭할 때 해당 알림이 읽음 상태로 자동 처리되고 관련 콘텐츠 화면으로 올바르게 이동합니다.
  * 알림 화면의 사용자 인터페이스 레이아웃이 개선되어 더욱 최적화된 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->