### PR TITLE
API Base URL 런타임 동적 변경 기능 추가 : fix : 서버 로그 URL 변경 후 SSE 재연결 안 되는 버그 수정

### DIFF
--- a/lib/debug/runtime_url_manager.dart
+++ b/lib/debug/runtime_url_manager.dart
@@ -1,4 +1,3 @@
-// lib/debug/runtime_url_manager.dart
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -12,6 +11,8 @@ class RuntimeUrlManager {
 
   String _currentBaseUrl = _prodUrl;
 
+  final List<void Function(String)> _listeners = [];
+
   String get baseUrl {
     if (!kDebugMode) return _prodUrl;
     return _currentBaseUrl;
@@ -19,6 +20,20 @@ class RuntimeUrlManager {
 
   static String buildPreviewUrl(String prNumber) {
     return 'http://romrom-pr-$prNumber.pr.suhsaechan.kr:8079';
+  }
+
+  void addUrlChangeListener(void Function(String) listener) {
+    _listeners.add(listener);
+  }
+
+  void removeUrlChangeListener(void Function(String) listener) {
+    _listeners.remove(listener);
+  }
+
+  void _notifyListeners(String url) {
+    for (final listener in List.of(_listeners)) {
+      listener(url);
+    }
   }
 
   /// 앱 시작 시 호출 — SharedPreferences에서 저장된 URL 복원
@@ -36,6 +51,7 @@ class RuntimeUrlManager {
     _currentBaseUrl = url;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_prefsKey, url);
+    _notifyListeners(url);
   }
 
   Future<void> resetToDefault() async {
@@ -43,6 +59,7 @@ class RuntimeUrlManager {
     _currentBaseUrl = _prodUrl;
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_prefsKey);
+    _notifyListeners(_prodUrl);
   }
 
   bool get isUsingProd => _currentBaseUrl == _prodUrl;

--- a/lib/debug/server_log_client.dart
+++ b/lib/debug/server_log_client.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:romrom_fe/debug/log_capture.dart';
+import 'package:romrom_fe/debug/runtime_url_manager.dart';
 import 'package:romrom_fe/models/app_urls.dart';
 import 'package:romrom_fe/utils/secured_api_utils.dart';
 
@@ -22,6 +23,13 @@ class ServerLogClient {
   bool _shouldReconnect = false;
   Timer? _reconnectTimer;
 
+  void _onUrlChanged(String _) {
+    if (_shouldReconnect) {
+      _addSystemLog('[서버 로그] URL 변경 감지 — 재연결 중...');
+      _doConnect();
+    }
+  }
+
   /// 현재 버퍼의 로그 목록
   List<CapturedLog> get logs => List.unmodifiable(_buffer);
 
@@ -34,6 +42,7 @@ class ServerLogClient {
   /// SSE 연결 시작
   Future<void> connect() async {
     _shouldReconnect = true;
+    RuntimeUrlManager().addUrlChangeListener(_onUrlChanged);
     await _doConnect();
   }
 
@@ -145,7 +154,10 @@ class ServerLogClient {
 
   /// 연결 종료
   void disconnect({bool permanent = true}) {
-    if (permanent) _shouldReconnect = false;
+    if (permanent) {
+      _shouldReconnect = false;
+      RuntimeUrlManager().removeUrlChangeListener(_onUrlChanged);
+    }
     _reconnectTimer?.cancel();
     _sseSubscription?.cancel();
     _sseSubscription = null;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1091,18 +1091,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1672,10 +1672,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
## 문제

`ServerLogClient`가 URL 변경을 감지하지 못해, `서버 URL 변경` 패널에서 PR 서버로 전환해도 서버 로그 SSE 연결이 이전 URL에 붙어있는 버그

## 원인

`RuntimeUrlManager.setBaseUrl()` 호출 후 이미 열려있는 SSE 연결을 재연결하는 로직이 없었음

## 수정

- `RuntimeUrlManager`에 URL 변경 리스너 추가/제거/알림 메서드 추가
- `ServerLogClient.connect()` 시 리스너 등록, URL 변경 감지 즉시 `_doConnect()` 재연결
- `ServerLogClient.disconnect(permanent: true)` 시 리스너 해제

Closes #793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * URL 변경 감지 및 자동 알림 메커니즘 추가
  * 런타임 서버 주소 변경 시 자동으로 연결 재설정
  * 동적 서버 주소 변경에 대한 실시간 대응 지원

* **개선 사항**
  * 디버그 환경에서의 서버 연결 관리 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->