### PR TITLE
서버로그 URL 변경 후 재연결 버그 수정 및 SSE 슬롯 누수 방지

### DIFF
--- a/lib/debug/debug_overlay_manager.dart
+++ b/lib/debug/debug_overlay_manager.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:romrom_fe/debug/server_log_client.dart';
 import 'package:romrom_fe/debug/widgets/debug_log_panel.dart';
 import 'package:romrom_fe/debug/widgets/debug_menu_panel.dart';
 import 'package:romrom_fe/debug/widgets/debug_server_log_panel.dart';
@@ -11,6 +12,9 @@ class DebugOverlayManager {
   static final DebugOverlayManager _instance = DebugOverlayManager._internal();
   factory DebugOverlayManager() => _instance;
   DebugOverlayManager._internal();
+
+  /// 앱 전역 ServerLogClient 싱글톤 — 백그라운드 suspend/resume 제어용
+  final ServerLogClient serverLogClient = ServerLogClient();
 
   GlobalKey<NavigatorState>? _navigatorKey;
   OverlayEntry? _buttonEntry;
@@ -176,8 +180,19 @@ class DebugOverlayManager {
     _isUrlPanelOpen = false;
   }
 
+  /// 앱 백그라운드 진입 시 SSE 연결 중단 (슬롯 반환)
+  void suspendServerLog() {
+    serverLogClient.suspend();
+  }
+
+  /// 앱 포그라운드 복귀 시 SSE 재연결
+  void resumeServerLog() {
+    serverLogClient.resume();
+  }
+
   /// 리소스 정리
   void dispose() {
+    serverLogClient.disconnect();
     _closeMenu();
     _closeLogPanel();
     _closeServerLogPanel();

--- a/lib/debug/runtime_url_manager.dart
+++ b/lib/debug/runtime_url_manager.dart
@@ -1,4 +1,3 @@
-// lib/debug/runtime_url_manager.dart
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -12,6 +11,8 @@ class RuntimeUrlManager {
 
   String _currentBaseUrl = _prodUrl;
 
+  final List<void Function(String)> _listeners = [];
+
   String get baseUrl {
     if (!kDebugMode) return _prodUrl;
     return _currentBaseUrl;
@@ -19,6 +20,20 @@ class RuntimeUrlManager {
 
   static String buildPreviewUrl(String prNumber) {
     return 'http://romrom-pr-$prNumber.pr.suhsaechan.kr:8079';
+  }
+
+  void addUrlChangeListener(void Function(String) listener) {
+    _listeners.add(listener);
+  }
+
+  void removeUrlChangeListener(void Function(String) listener) {
+    _listeners.remove(listener);
+  }
+
+  void _notifyListeners(String url) {
+    for (final listener in List.of(_listeners)) {
+      listener(url);
+    }
   }
 
   /// 앱 시작 시 호출 — SharedPreferences에서 저장된 URL 복원
@@ -36,6 +51,7 @@ class RuntimeUrlManager {
     _currentBaseUrl = url;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_prefsKey, url);
+    _notifyListeners(url);
   }
 
   Future<void> resetToDefault() async {
@@ -43,6 +59,7 @@ class RuntimeUrlManager {
     _currentBaseUrl = _prodUrl;
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_prefsKey);
+    _notifyListeners(_prodUrl);
   }
 
   bool get isUsingProd => _currentBaseUrl == _prodUrl;

--- a/lib/debug/server_log_client.dart
+++ b/lib/debug/server_log_client.dart
@@ -12,6 +12,7 @@ import 'package:romrom_fe/utils/secured_api_utils.dart';
 class ServerLogClient {
   static String get _endpoint => '${AppUrls.baseUrl}/api/app/debug/log-stream';
   static const Duration _reconnectDelay = Duration(seconds: 3);
+  static const Duration _reconnectDelayOnCapacityExceeded = Duration(seconds: 15);
   static const int _maxBufferSize = 1000;
 
   final List<CapturedLog> _buffer = [];
@@ -60,6 +61,14 @@ class ServerLogClient {
       _httpClient = http.Client();
       final response = await _httpClient!.send(request);
 
+      if (response.statusCode == 503) {
+        // 구독자 수 초과 — BE 슬롯이 해제될 때까지 대기 후 재시도
+        final body = await response.stream.bytesToString();
+        _addSystemLog('[서버 로그] 구독자 수 초과 (503) — ${_reconnectDelayOnCapacityExceeded.inSeconds}초 후 재시도');
+        debugPrint('[ServerLogClient] 503 body: $body');
+        _scheduleReconnect(delay: _reconnectDelayOnCapacityExceeded);
+        return;
+      }
       if (response.statusCode != 200) {
         final body = await response.stream.bytesToString();
         _addSystemLog('[서버 로그] 연결 실패: ${response.statusCode} $body');
@@ -139,12 +148,26 @@ class ServerLogClient {
     _addLog(CapturedLog(time: DateTime.now(), message: message));
   }
 
-  void _scheduleReconnect() {
+  void _scheduleReconnect({Duration? delay}) {
     if (!_shouldReconnect) return;
     _reconnectTimer?.cancel();
-    _reconnectTimer = Timer(_reconnectDelay, () {
+    _reconnectTimer = Timer(delay ?? _reconnectDelay, () {
       if (_shouldReconnect) _doConnect();
     });
+  }
+
+  /// 백그라운드 진입 시 연결 일시 중단 (슬롯 반환)
+  void suspend() {
+    disconnect(permanent: false);
+    _addSystemLog('[서버 로그] 백그라운드 전환 — 연결 중단');
+  }
+
+  /// 포그라운드 복귀 시 연결 재개
+  void resume() {
+    if (_shouldReconnect) {
+      _addSystemLog('[서버 로그] 포그라운드 복귀 — 재연결 중...');
+      _doConnect();
+    }
   }
 
   /// 버퍼 비우기

--- a/lib/debug/server_log_client.dart
+++ b/lib/debug/server_log_client.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:romrom_fe/debug/log_capture.dart';
+import 'package:romrom_fe/debug/runtime_url_manager.dart';
 import 'package:romrom_fe/models/app_urls.dart';
 import 'package:romrom_fe/utils/secured_api_utils.dart';
 
@@ -22,6 +23,13 @@ class ServerLogClient {
   bool _shouldReconnect = false;
   Timer? _reconnectTimer;
 
+  void _onUrlChanged(String _) {
+    if (_shouldReconnect) {
+      _addSystemLog('[서버 로그] URL 변경 감지 — 재연결 중...');
+      _doConnect();
+    }
+  }
+
   /// 현재 버퍼의 로그 목록
   List<CapturedLog> get logs => List.unmodifiable(_buffer);
 
@@ -34,6 +42,7 @@ class ServerLogClient {
   /// SSE 연결 시작
   Future<void> connect() async {
     _shouldReconnect = true;
+    RuntimeUrlManager().addUrlChangeListener(_onUrlChanged);
     await _doConnect();
   }
 
@@ -145,7 +154,10 @@ class ServerLogClient {
 
   /// 연결 종료
   void disconnect({bool permanent = true}) {
-    if (permanent) _shouldReconnect = false;
+    if (permanent) {
+      _shouldReconnect = false;
+      RuntimeUrlManager().removeUrlChangeListener(_onUrlChanged);
+    }
     _reconnectTimer?.cancel();
     _sseSubscription?.cancel();
     _sseSubscription = null;

--- a/lib/debug/widgets/debug_server_log_panel.dart
+++ b/lib/debug/widgets/debug_server_log_panel.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:romrom_fe/debug/debug_overlay_manager.dart';
 import 'package:romrom_fe/debug/log_capture.dart';
 import 'package:romrom_fe/debug/server_log_client.dart';
 import 'package:romrom_fe/models/app_colors.dart';
@@ -27,8 +28,8 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
   static const double _minWidth = 280;
   static const double _minHeight = 200;
 
-  // 서버 로그 클라이언트
-  final ServerLogClient _client = ServerLogClient();
+  // 서버 로그 클라이언트 (DebugOverlayManager 싱글톤 — 백그라운드 suspend/resume 공유)
+  ServerLogClient get _client => DebugOverlayManager().serverLogClient;
   StreamSubscription<CapturedLog>? _subscription;
   Timer? _debounceTimer;
   List<CapturedLog> _filteredLogs = [];
@@ -72,7 +73,7 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
     _debounceTimer?.cancel();
     _scrollController.dispose();
     _searchController.dispose();
-    _client.disconnect();
+    // 싱글톤 클라이언트이므로 패널 닫힘 시 disconnect하지 않음 — DebugOverlayManager.dispose()에서 관리
     super.dispose();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -164,6 +164,13 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
       _checkVersionOnResume();
+      if (DebugConfig.isTestBuild) {
+        DebugOverlayManager().resumeServerLog();
+      }
+    } else if (state == AppLifecycleState.paused) {
+      if (DebugConfig.isTestBuild) {
+        DebugOverlayManager().suspendServerLog();
+      }
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -1091,18 +1091,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1672,10 +1672,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1091,18 +1091,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1672,10 +1672,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- 앱 백그라운드(`paused`) 전환 시 SSE 연결 즉시 종료 → BE 슬롯 즉시 반환
- 포그라운드(`resumed`) 복귀 시 SSE 자동 재연결
- 503 (구독자 수 초과) 에러 시 3초 → 15초 대기 후 재시도
- `ServerLogClient`를 `DebugOverlayManager` 싱글톤으로 통합하여 앱 라이프사이클에서 중앙 제어

## Related Issue
Closes #793

## Background
BE SSE 구독자 슬롯(최대 10개)이 클라이언트 단절 후 해제되지 않는 문제와 연계된 FE 버그.
앱이 백그라운드로 가도 SSE 연결을 유지해 슬롯을 점유하고, 503 에러 시 3초마다 무한 재연결을 시도하여 슬롯이 빠르게 소진됨.

## Test plan
- [ ] 서버 로그 패널 열고 앱 백그라운드 전환 시 연결 종료 로그 확인
- [ ] 포그라운드 복귀 시 자동 재연결 확인
- [ ] 서버 로그 패널 닫힌 상태에서 백그라운드 전환 시 resume 후 재연결 없음 확인
- [ ] 서버 구독자 10명 초과 시 15초 대기 후 재시도 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)