### PR TITLE
API Base URL 런타임 동적 변경 기능 추가 : fix : 서버 URL 변경 시 토큰 초기화 후 로그인 화면 이동

### DIFF
--- a/lib/debug/widgets/debug_url_panel.dart
+++ b/lib/debug/widgets/debug_url_panel.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:romrom_fe/debug/runtime_url_manager.dart';
+import 'package:romrom_fe/enums/navigation_types.dart';
 import 'package:romrom_fe/models/app_colors.dart';
+import 'package:romrom_fe/screens/login_screen.dart';
+import 'package:romrom_fe/services/token_manager.dart';
+import 'package:romrom_fe/utils/common_utils.dart';
 
 class DebugUrlPanel extends StatefulWidget {
   final VoidCallback onClose;
@@ -39,23 +43,22 @@ class _DebugUrlPanelState extends State<DebugUrlPanel> {
     setState(() => _isLoading = true);
     final url = RuntimeUrlManager.buildPreviewUrl(input);
     await RuntimeUrlManager().setBaseUrl(url);
-    if (mounted) {
-      setState(() {
-        _currentUrl = url;
-        _isLoading = false;
-        _controller.clear();
-      });
-    }
+    await _logoutAndNavigate();
   }
 
   Future<void> _resetToProd() async {
     setState(() => _isLoading = true);
     await RuntimeUrlManager().resetToDefault();
+    await _logoutAndNavigate();
+  }
+
+  /// URL 변경 후 토큰 초기화 + 로그인 화면으로 이동
+  /// PR 서버는 별도 DB라 기존 토큰이 유효하지 않으므로 재로그인 필요
+  Future<void> _logoutAndNavigate() async {
+    await TokenManager().deleteTokens();
     if (mounted) {
-      setState(() {
-        _currentUrl = RuntimeUrlManager().baseUrl;
-        _isLoading = false;
-      });
+      widget.onClose();
+      context.navigateTo(screen: const LoginScreen(), type: NavigationTypes.pushAndRemoveUntil);
     }
   }
 


### PR DESCRIPTION
## 문제

PR 서버는 prod와 별도 DB를 사용하므로, prod에서 발급된 JWT 토큰이 서명 검증은 통과해도 해당 유저가 PR 서버 DB에 존재하지 않아 API 호출이 실패

## 수정

`DebugUrlPanel`에서 URL 변경(연결/초기화) 시:
1. `TokenManager.deleteTokens()` — 로컬 토큰 삭제
2. 패널 닫기
3. `LoginScreen`으로 `pushAndRemoveUntil` 이동

이후 새 서버에서 재로그인하면 해당 서버의 DB 기준으로 정상 인증됨

Closes #793