### PR TITLE
광고 로딩 중 하단 아이템 카드 미노출 개선 : feat : 광고 슬롯에서도 카드 덱 항상 표시

### DIFF
--- a/lib/screens/home_tab_screen.dart
+++ b/lib/screens/home_tab_screen.dart
@@ -672,8 +672,8 @@ class _HomeTabScreenState extends State<HomeTabScreen> {
             ),
           ),
 
-        // 하단 고정 카드 덱 - 광고 슬롯에서는 숨김
-        if (!_isBlurShown && !_isAdAtVirtualIndex(_currentVirtualIndex))
+        // 하단 고정 카드 덱
+        if (!_isBlurShown)
           Positioned(
             left: 0,
             right: 0,

--- a/lib/screens/home_tab_screen.dart
+++ b/lib/screens/home_tab_screen.dart
@@ -682,6 +682,7 @@ class _HomeTabScreenState extends State<HomeTabScreen> {
               cards: _myCards,
               onCardDrop: _handleCardDrop,
               highlightedItemIds: _aiHighlightedItemIds,
+              dragEnabled: !_isAdAtVirtualIndex(_currentVirtualIndex),
             ),
           )
         else if (!_isAdAtVirtualIndex(_currentVirtualIndex))

--- a/lib/widgets/home_tab_card_hand.dart
+++ b/lib/widgets/home_tab_card_hand.dart
@@ -198,6 +198,24 @@ class _HomeTabCardHandState extends State<HomeTabCardHand> with TickerProviderSt
   void didUpdateWidget(HomeTabCardHand oldWidget) {
     super.didUpdateWidget(oldWidget);
 
+    // dragEnabled가 true→false로 바뀌면 진행 중인 제스처 상태 전부 정리
+    if (oldWidget.dragEnabled && !widget.dragEnabled) {
+      _longPressTimer?.cancel();
+      _longPressTimer = null;
+      _pullController.reverse();
+      setState(() {
+        _panStartedOnCard = false;
+        _startCardId = null;
+        _hasStartedCardDrag = false;
+        _pressedCardId = null;
+        _hoveredCardId = null;
+        _pulledCardId = null;
+        _pullOffset = Offset.zero;
+        _dropShadowT = 0.0;
+        _wasOverDropZone = false;
+      });
+    }
+
     if (!listEquals(widget.highlightedItemIds, oldWidget.highlightedItemIds)) {
       if (widget.highlightedItemIds.isNotEmpty) {
         if (!_highlightPulseController.isAnimating) {

--- a/lib/widgets/home_tab_card_hand.dart
+++ b/lib/widgets/home_tab_card_hand.dart
@@ -22,7 +22,16 @@ class HomeTabCardHand extends StatefulWidget {
   /// AI 추천 상위 3개 itemId 목록 - 해당 카드에 glow boxShadow 효과 적용
   final List<String> highlightedItemIds;
 
-  const HomeTabCardHand({super.key, this.onCardDrop, this.cards, this.highlightedItemIds = const []});
+  /// 드래그 인터랙션 활성화 여부 (광고 슬롯에서 false)
+  final bool dragEnabled;
+
+  const HomeTabCardHand({
+    super.key,
+    this.onCardDrop,
+    this.cards,
+    this.highlightedItemIds = const [],
+    this.dragEnabled = true,
+  });
 
   @override
   State<HomeTabCardHand> createState() => _HomeTabCardHandState();
@@ -889,11 +898,11 @@ class _HomeTabCardHandState extends State<HomeTabCardHand> with TickerProviderSt
       children: [
         // 덱(카드 핸드) 영역
         GestureDetector(
-          // 드래그 제스처
-          onPanStart: _handlePanStart,
-          onPanUpdate: _handlePanUpdate,
-          onPanEnd: _handlePanEnd,
-          onPanCancel: _handlePanCancel,
+          // 광고 슬롯에서는 드래그 비활성화
+          onPanStart: widget.dragEnabled ? _handlePanStart : null,
+          onPanUpdate: widget.dragEnabled ? _handlePanUpdate : null,
+          onPanEnd: widget.dragEnabled ? _handlePanEnd : null,
+          onPanCancel: widget.dragEnabled ? _handlePanCancel : null,
           child: SizedBox(
             height: 280.h,
             child: Stack(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1107,10 +1107,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1672,10 +1672,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1107,10 +1107,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1672,10 +1672,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- 광고 슬롯에서도 하단 카드 덱(`HomeTabCardHand`)이 항상 표시되도록 조건 수정
- 기존에는 광고 페이지 진입 시 카드 덱이 숨겨져 사용자가 교환 카드를 볼 수 없었음

## Changes
- `home_tab_screen.dart`: 카드 덱 표시 조건에서 `!_isAdAtVirtualIndex(_currentVirtualIndex)` 제거

Closes #789

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 화면 흐림(블러)이 표시되지 않을 때 홈 탭의 카드 패널이 항상 표시되도록 개선했습니다.
  * 광고 슬롯에서는 카드 끌기(드래그) 동작이 비활성화되어 의도치 않은 상호작용을 방지합니다.
  * 광고 슬롯 조건에서 플로팅 액션(등록하기)이 더 이상 표시되지 않도록 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->