### PR TITLE
로딩 인디케이터 통일 필요 : feat : CommonLoadingIndicator 적용 및 스켈레톤 추가

### DIFF
--- a/docs/superpowers/plans/2026-04-19-loading-indicator-unification.md
+++ b/docs/superpowers/plans/2026-04-19-loading-indicator-unification.md
@@ -1,0 +1,838 @@
+# 로딩 인디케이터 통일 구현 계획 (#761)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 토스 앱 스타일로 로딩 경험 통일 — 초기 로딩은 shimmer 스켈레톤, 인라인/페이징은 공통 스피너
+
+**Architecture:** `CommonLoadingIndicator` 공통 위젯 신규 생성 후 33개 파일의 `CircularProgressIndicator` 직접 사용을 교체. 5개 화면의 초기 로딩에 shimmer 스켈레톤 신규 추가. 기존 3개 스켈레톤은 유지.
+
+**Tech Stack:** Flutter, skeletonizer ^2.1.0+1 (추가 패키지 없음), AppColors, CustomTextStyles
+
+---
+
+## 파일 구조
+
+**신규 생성:**
+- `lib/widgets/common/loading_indicator.dart` — `CommonLoadingIndicator` 스피너 래퍼
+- `lib/widgets/skeletons/home_feed_skeleton.dart` — 홈 피드 초기 로딩 스켈레톤
+- `lib/widgets/skeletons/item_detail_skeleton.dart` — 물품 상세 초기 로딩 스켈레톤
+- `lib/widgets/skeletons/my_like_list_skeleton.dart` — 찜 목록 초기 로딩 스켈레톤
+- `lib/widgets/skeletons/notification_settings_skeleton.dart` — 알림 설정 초기 로딩 스켈레톤
+- `lib/widgets/skeletons/trade_partner_select_skeleton.dart` — 거래 파트너 선택 스켈레톤
+
+**수정:**
+- `lib/screens/home_tab_screen.dart` — 초기 로딩 스피너 → 스켈레톤, 페이징 스피너 → CommonLoadingIndicator
+- `lib/screens/item_detail_description_screen.dart` — 초기 로딩 스피너 → 스켈레톤
+- `lib/screens/my_page/my_like_list_screen.dart` — 초기 로딩 스피너 → 스켈레톤, 페이징 → CommonLoadingIndicator
+- `lib/screens/notification_settings_screen.dart` — 초기 로딩 스피너 → 스켈레톤
+- `lib/screens/trade_complete_partner_select_screen.dart` — 초기 로딩 스피너 → 스켈레톤
+- 그 외 28개 파일 — `CircularProgressIndicator` → `CommonLoadingIndicator`
+
+---
+
+## Task 1: CommonLoadingIndicator 공통 위젯 생성
+
+**Files:**
+- Create: `lib/widgets/common/loading_indicator.dart`
+
+- [ ] **Step 1: 파일 생성**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:romrom_fe/models/app_colors.dart';
+
+/// 앱 전역 공통 로딩 스피너. CircularProgressIndicator 직접 사용 금지 — 이 위젯 사용.
+class CommonLoadingIndicator extends StatelessWidget {
+  const CommonLoadingIndicator({super.key, this.color = AppColors.primaryYellow, this.size = 24.0});
+
+  /// 버튼 내부 흰색 스피너용 named constructor
+  const CommonLoadingIndicator.white({super.key, this.size = 18.0}) : color = AppColors.textColorWhite;
+
+  final Color color;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: size,
+      height: size,
+      child: CircularProgressIndicator(
+        strokeWidth: 2.0,
+        valueColor: AlwaysStoppedAnimation<Color>(color),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 2: 포맷 적용**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/widgets/common/loading_indicator.dart
+```
+
+- [ ] **Step 3: 린트 확인**
+
+```bash
+source ~/.zshrc && flutter analyze lib/widgets/common/loading_indicator.dart
+```
+Expected: No issues found.
+
+---
+
+## Task 2: HomeFeedSkeleton 스켈레톤 생성
+
+홈 피드는 `PageView.builder` 기반 세로 스크롤 구조. 초기 로딩 시 전체 화면을 shimmer로 채운다.
+
+**Files:**
+- Create: `lib/widgets/skeletons/home_feed_skeleton.dart`
+
+- [ ] **Step 1: 파일 생성**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:romrom_fe/models/app_colors.dart';
+
+/// 홈 피드 초기 로딩 스켈레톤 — PageView 전체화면 shimmer
+class HomeFeedSkeleton extends StatelessWidget {
+  const HomeFeedSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    final height = MediaQuery.of(context).size.height;
+
+    return Skeletonizer(
+      enabled: true,
+      effect: const ShimmerEffect(
+        baseColor: AppColors.opacity10White,
+        highlightColor: AppColors.opacity30White,
+      ),
+      child: Container(
+        width: width,
+        height: height,
+        color: AppColors.primaryBlack,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 이미지 영역 (화면 상단 대부분 차지)
+            Skeleton.leaf(
+              child: Container(
+                width: width,
+                height: height * 0.6,
+                color: AppColors.opacity10White,
+              ),
+            ),
+            const SizedBox(height: 16),
+            // 제목 라인
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.55, height: 18, color: AppColors.opacity10White),
+                  ),
+                  const SizedBox(height: 10),
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.35, height: 15, color: AppColors.opacity10White),
+                  ),
+                  const SizedBox(height: 10),
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.45, height: 13, color: AppColors.opacity10White),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 2: 포맷 및 린트**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/widgets/skeletons/home_feed_skeleton.dart && flutter analyze lib/widgets/skeletons/home_feed_skeleton.dart
+```
+Expected: No issues found.
+
+---
+
+## Task 3: ItemDetailSkeleton 스켈레톤 생성
+
+물품 상세 화면 구조: 전체 너비 이미지 → 프로필 → 제목/가격 → 설명.
+
+**Files:**
+- Create: `lib/widgets/skeletons/item_detail_skeleton.dart`
+
+- [ ] **Step 1: 파일 생성**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:romrom_fe/models/app_colors.dart';
+
+/// 물품 상세 초기 로딩 스켈레톤
+class ItemDetailSkeleton extends StatelessWidget {
+  const ItemDetailSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+
+    return Skeletonizer(
+      enabled: true,
+      effect: const ShimmerEffect(
+        baseColor: AppColors.opacity10White,
+        highlightColor: AppColors.opacity30White,
+      ),
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 이미지 영역
+            Skeleton.leaf(
+              child: Container(width: width, height: 300, color: AppColors.opacity10White),
+            ),
+            const SizedBox(height: 16),
+            // 프로필 행
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  Skeleton.leaf(
+                    child: const CircleAvatar(radius: 20, backgroundColor: AppColors.opacity10White),
+                  ),
+                  const SizedBox(width: 10),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Skeleton.leaf(
+                        child: Container(width: 80, height: 13, color: AppColors.opacity10White),
+                      ),
+                      const SizedBox(height: 6),
+                      Skeleton.leaf(
+                        child: Container(width: 55, height: 11, color: AppColors.opacity10White),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 20),
+            // 제목 + 가격
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.7, height: 18, color: AppColors.opacity10White),
+                  ),
+                  const SizedBox(height: 10),
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.4, height: 16, color: AppColors.opacity10White),
+                  ),
+                  const SizedBox(height: 16),
+                  // 설명 텍스트 3줄
+                  Skeleton.leaf(
+                    child: Container(width: width - 32, height: 12, color: AppColors.opacity10White),
+                  ),
+                  const SizedBox(height: 6),
+                  Skeleton.leaf(
+                    child: Container(width: (width - 32) * 0.85, height: 12, color: AppColors.opacity10White),
+                  ),
+                  const SizedBox(height: 6),
+                  Skeleton.leaf(
+                    child: Container(width: (width - 32) * 0.6, height: 12, color: AppColors.opacity10White),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 2: 포맷 및 린트**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/widgets/skeletons/item_detail_skeleton.dart && flutter analyze lib/widgets/skeletons/item_detail_skeleton.dart
+```
+Expected: No issues found.
+
+---
+
+## Task 4: MyLikeListSkeleton 스켈레톤 생성
+
+찜 목록은 `ListView.separated` 구조. 썸네일(64×64) + 텍스트 3줄.
+
+**Files:**
+- Create: `lib/widgets/skeletons/my_like_list_skeleton.dart`
+
+- [ ] **Step 1: 파일 생성**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:romrom_fe/models/app_colors.dart';
+
+/// 찜 목록 초기 로딩 스켈레톤
+class MyLikeListSkeleton extends StatelessWidget {
+  const MyLikeListSkeleton({super.key, this.itemCount = 6});
+
+  final int itemCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+
+    return ListView.separated(
+      physics: const NeverScrollableScrollPhysics(),
+      shrinkWrap: true,
+      itemCount: itemCount,
+      separatorBuilder: (_, _) => const Divider(color: AppColors.opacity10White, thickness: 1.5),
+      itemBuilder: (_, __) => Skeletonizer(
+        enabled: true,
+        effect: const ShimmerEffect(
+          baseColor: AppColors.opacity10White,
+          highlightColor: AppColors.opacity30White,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          child: Row(
+            children: [
+              // 썸네일 (정사각형)
+              Skeleton.leaf(
+                child: Container(
+                  width: 64,
+                  height: 64,
+                  decoration: BoxDecoration(
+                    color: AppColors.opacity10White,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              // 텍스트 3줄
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.45, height: 13, color: AppColors.opacity10White),
+                  ),
+                  const SizedBox(height: 6),
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.3, height: 11, color: AppColors.opacity10White),
+                  ),
+                  const SizedBox(height: 6),
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.55, height: 11, color: AppColors.opacity10White),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 2: 포맷 및 린트**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/widgets/skeletons/my_like_list_skeleton.dart && flutter analyze lib/widgets/skeletons/my_like_list_skeleton.dart
+```
+Expected: No issues found.
+
+---
+
+## Task 5: NotificationSettingsSkeleton 스켈레톤 생성
+
+알림 설정은 `SingleChildScrollView > Column` 구조. 각 행: 텍스트 2줄 + 토글 자리.
+
+**Files:**
+- Create: `lib/widgets/skeletons/notification_settings_skeleton.dart`
+
+- [ ] **Step 1: 파일 생성**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:romrom_fe/models/app_colors.dart';
+
+/// 알림 설정 초기 로딩 스켈레톤
+class NotificationSettingsSkeleton extends StatelessWidget {
+  const NotificationSettingsSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
+      child: Column(
+        children: [
+          _buildGroup(width, 4),
+          const SizedBox(height: 16),
+          _buildGroup(width, 1),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildGroup(double width, int rowCount) {
+    return Container(
+      decoration: BoxDecoration(
+        color: const Color(0xFF34353D), // AppColors.secondaryBlack1
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        children: List.generate(rowCount, (i) => _buildRow(width, i, rowCount)),
+      ),
+    );
+  }
+
+  Widget _buildRow(double width, int index, int total) {
+    return Skeletonizer(
+      enabled: true,
+      effect: const ShimmerEffect(
+        baseColor: AppColors.opacity10White,
+        highlightColor: AppColors.opacity30White,
+      ),
+      child: SizedBox(
+        height: 74,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: [
+              // 텍스트 영역
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Skeleton.leaf(
+                      child: Container(width: width * 0.35, height: 13, color: AppColors.opacity10White),
+                    ),
+                    const SizedBox(height: 8),
+                    Skeleton.leaf(
+                      child: Container(width: width * 0.55, height: 11, color: AppColors.opacity10White),
+                    ),
+                  ],
+                ),
+              ),
+              // 토글 자리
+              Skeleton.leaf(
+                child: Container(
+                  width: 44,
+                  height: 26,
+                  decoration: BoxDecoration(
+                    color: AppColors.opacity10White,
+                    borderRadius: BorderRadius.circular(13),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 2: 포맷 및 린트**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/widgets/skeletons/notification_settings_skeleton.dart && flutter analyze lib/widgets/skeletons/notification_settings_skeleton.dart
+```
+Expected: No issues found.
+
+---
+
+## Task 6: TradePartnerSelectSkeleton 스켈레톤 생성
+
+거래 파트너 선택은 `ListView` 구조. 각 행: 원형 프로필 + 이름/위치 2줄 + 버튼 자리.
+
+**Files:**
+- Create: `lib/widgets/skeletons/trade_partner_select_skeleton.dart`
+
+- [ ] **Step 1: 파일 생성**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:romrom_fe/models/app_colors.dart';
+
+/// 거래 파트너 선택 초기 로딩 스켈레톤
+class TradePartnerSelectSkeleton extends StatelessWidget {
+  const TradePartnerSelectSkeleton({super.key, this.itemCount = 4});
+
+  final int itemCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+
+    return ListView.builder(
+      physics: const NeverScrollableScrollPhysics(),
+      shrinkWrap: true,
+      itemCount: itemCount,
+      itemBuilder: (_, __) => Skeletonizer(
+        enabled: true,
+        effect: const ShimmerEffect(
+          baseColor: AppColors.opacity10White,
+          highlightColor: AppColors.opacity30White,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 10),
+          child: Row(
+            children: [
+              // 원형 프로필
+              Skeleton.leaf(
+                child: const CircleAvatar(radius: 22, backgroundColor: AppColors.opacity10White),
+              ),
+              const SizedBox(width: 12),
+              // 이름 + 위치
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Skeleton.leaf(
+                      child: Container(width: width * 0.35, height: 13, color: AppColors.opacity10White),
+                    ),
+                    const SizedBox(height: 6),
+                    Skeleton.leaf(
+                      child: Container(width: width * 0.25, height: 11, color: AppColors.opacity10White),
+                    ),
+                  ],
+                ),
+              ),
+              // 선택 버튼 자리
+              Skeleton.leaf(
+                child: Container(
+                  width: 60,
+                  height: 30,
+                  decoration: BoxDecoration(
+                    color: AppColors.opacity10White,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 2: 포맷 및 린트**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/widgets/skeletons/trade_partner_select_skeleton.dart && flutter analyze lib/widgets/skeletons/trade_partner_select_skeleton.dart
+```
+Expected: No issues found.
+
+---
+
+## Task 7: 홈 피드 로딩 교체
+
+**Files:**
+- Modify: `lib/screens/home_tab_screen.dart:529-530, 593`
+
+- [ ] **Step 1: import 추가**
+
+파일 상단 import 목록에 추가:
+```dart
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
+import 'package:romrom_fe/widgets/skeletons/home_feed_skeleton.dart';
+```
+
+- [ ] **Step 2: 초기 로딩 교체 (line ~529)**
+
+변경 전:
+```dart
+if (_isLoading) {
+  return const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow));
+}
+```
+
+변경 후:
+```dart
+if (_isLoading) {
+  return const HomeFeedSkeleton();
+}
+```
+
+- [ ] **Step 3: 페이징 로딩 교체 (line ~593)**
+
+변경 전:
+```dart
+return const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow));
+```
+
+변경 후:
+```dart
+return const Center(child: CommonLoadingIndicator());
+```
+
+- [ ] **Step 4: 포맷 및 린트**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/screens/home_tab_screen.dart && flutter analyze lib/screens/home_tab_screen.dart
+```
+Expected: No issues found.
+
+---
+
+## Task 8: 물품 상세 로딩 교체
+
+**Files:**
+- Modify: `lib/screens/item_detail_description_screen.dart:330`
+
+- [ ] **Step 1: import 추가**
+
+```dart
+import 'package:romrom_fe/widgets/skeletons/item_detail_skeleton.dart';
+```
+
+- [ ] **Step 2: 초기 로딩 교체 (line ~330)**
+
+변경 전:
+```dart
+body: Center(child: CircularProgressIndicator(color: AppColors.primaryYellow)),
+```
+
+변경 후:
+```dart
+body: const ItemDetailSkeleton(),
+```
+
+- [ ] **Step 3: 포맷 및 린트**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/screens/item_detail_description_screen.dart && flutter analyze lib/screens/item_detail_description_screen.dart
+```
+Expected: No issues found.
+
+---
+
+## Task 9: 찜 목록 로딩 교체
+
+**Files:**
+- Modify: `lib/screens/my_page/my_like_list_screen.dart:161-162, 188`
+
+- [ ] **Step 1: import 추가**
+
+```dart
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
+import 'package:romrom_fe/widgets/skeletons/my_like_list_skeleton.dart';
+```
+
+- [ ] **Step 2: 초기 로딩 교체 (line ~161)**
+
+변경 전:
+```dart
+body: _items.isEmpty && _isLoading
+    ? const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow))
+```
+
+변경 후:
+```dart
+body: _items.isEmpty && _isLoading
+    ? Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: const MyLikeListSkeleton(),
+      )
+```
+
+- [ ] **Step 3: 페이징 로딩 교체 (line ~182)**
+
+변경 전:
+```dart
+return Padding(
+  padding: EdgeInsets.symmetric(vertical: 16.h),
+  child: const Center(
+    child: SizedBox(
+      width: 20,
+      height: 20,
+      child: CircularProgressIndicator(color: AppColors.primaryYellow),
+    ),
+  ),
+);
+```
+
+변경 후:
+```dart
+return const Padding(
+  padding: EdgeInsets.symmetric(vertical: 16),
+  child: Center(child: CommonLoadingIndicator(size: 20)),
+);
+```
+
+- [ ] **Step 4: 포맷 및 린트**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/screens/my_page/my_like_list_screen.dart && flutter analyze lib/screens/my_page/my_like_list_screen.dart
+```
+Expected: No issues found.
+
+---
+
+## Task 10: 알림 설정 로딩 교체
+
+**Files:**
+- Modify: `lib/screens/notification_settings_screen.dart:129`
+
+- [ ] **Step 1: import 추가**
+
+```dart
+import 'package:romrom_fe/widgets/skeletons/notification_settings_skeleton.dart';
+```
+
+- [ ] **Step 2: 초기 로딩 교체 (line ~128)**
+
+변경 전:
+```dart
+body: _isLoading
+    ? const Center(child: CircularProgressIndicator())
+```
+
+변경 후:
+```dart
+body: _isLoading
+    ? const NotificationSettingsSkeleton()
+```
+
+- [ ] **Step 3: 포맷 및 린트**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/screens/notification_settings_screen.dart && flutter analyze lib/screens/notification_settings_screen.dart
+```
+Expected: No issues found.
+
+---
+
+## Task 11: 거래 파트너 선택 로딩 교체
+
+**Files:**
+- Modify: `lib/screens/trade_complete_partner_select_screen.dart:72`
+
+- [ ] **Step 1: import 추가**
+
+```dart
+import 'package:romrom_fe/widgets/skeletons/trade_partner_select_skeleton.dart';
+```
+
+- [ ] **Step 2: 초기 로딩 교체 (line ~71)**
+
+변경 전:
+```dart
+child: _isLoading
+    ? const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow))
+```
+
+변경 후:
+```dart
+child: _isLoading
+    ? const TradePartnerSelectSkeleton()
+```
+
+- [ ] **Step 3: 포맷 및 린트**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/screens/trade_complete_partner_select_screen.dart && flutter analyze lib/screens/trade_complete_partner_select_screen.dart
+```
+Expected: No issues found.
+
+---
+
+## Task 12: 나머지 28개 파일 CircularProgressIndicator 일괄 교체
+
+아래 파일들의 `CircularProgressIndicator`를 `CommonLoadingIndicator`로 교체한다.
+`color:` 인자는 제거(기본값 primaryYellow 사용). `strokeWidth:` 인자도 제거(2.0 고정).
+버튼 내부(`completion_button.dart`, `login_button.dart`)는 `CommonLoadingIndicator.white()` 사용.
+
+**Files:**
+- Modify: `lib/screens/register_tab_screen.dart`
+- Modify: `lib/screens/item_modification_screen.dart`
+- Modify: `lib/screens/chat_room_screen.dart`
+- Modify: `lib/screens/request_management_tab_screen.dart`
+- Modify: `lib/widgets/login_button.dart`
+- Modify: `lib/widgets/common/cached_image.dart`
+- Modify: `lib/widgets/common/completion_button.dart`
+- Modify: `lib/widgets/chat_message_item.dart`
+- Modify: `lib/widgets/chat_image_bubble.dart`
+- Modify: `lib/widgets/chat_location_bubble.dart`
+- Modify: `lib/widgets/register_input_form.dart`
+- 그 외 나머지 파일들
+
+- [ ] **Step 1: 각 파일에 import 추가 및 교체**
+
+각 파일마다:
+1. `import 'package:romrom_fe/widgets/common/loading_indicator.dart';` 추가
+2. `CircularProgressIndicator(color: AppColors.primaryYellow)` → `CommonLoadingIndicator()` 로 교체
+3. `SizedBox(width: N, height: N, child: CircularProgressIndicator(...))` → `CommonLoadingIndicator(size: N)` 로 교체
+4. 버튼 내부(흰 배경): `CommonLoadingIndicator.white()` 로 교체
+
+`completion_button.dart` 예시:
+
+변경 전:
+```dart
+CircularProgressIndicator(strokeWidth: 2, color: AppColors.textColorWhite)
+```
+
+변경 후:
+```dart
+const CommonLoadingIndicator.white()
+```
+
+`cached_image.dart` 예시:
+
+변경 전:
+```dart
+placeholder: (context, url) => const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow)),
+```
+
+변경 후:
+```dart
+placeholder: (context, url) => const Center(child: CommonLoadingIndicator()),
+```
+
+- [ ] **Step 2: 전체 포맷 및 린트**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 . && flutter analyze
+```
+Expected: No issues found.
+
+---
+
+## Task 13: 최종 검증 및 전체 린트
+
+- [ ] **Step 1: 전체 포맷 및 린트 최종 확인**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 . && flutter analyze
+```
+Expected: No issues found.
+
+- [ ] **Step 2: `CircularProgressIndicator` 직접 사용 잔존 여부 확인**
+
+```bash
+grep -rn "CircularProgressIndicator" lib/ --include="*.dart"
+```
+
+Expected: 결과 없음. (있으면 해당 파일도 교체)

--- a/docs/superpowers/specs/2026-04-19-loading-indicator-unification-design.md
+++ b/docs/superpowers/specs/2026-04-19-loading-indicator-unification-design.md
@@ -1,0 +1,126 @@
+# 로딩 인디케이터 통일 설계 (#761)
+
+## 배경
+
+현재 `CircularProgressIndicator`가 33개 파일에 직접 박혀 있고, 스켈레톤은 채팅 목록·물품 목록·등록 폼 3곳에만 적용되어 있다. 통일감이 없고 화면마다 로딩 경험이 다르다.
+
+목표: 토스 앱 스타일로 통일. 초기 로딩은 shimmer 스켈레톤, 인라인/페이징 로딩은 공통 스피너.
+
+---
+
+## 핵심 규칙
+
+| 상황 | 사용 위젯 |
+|------|----------|
+| 화면 초기 진입 (`_isLoading && items.isEmpty`) | 스켈레톤 |
+| 페이징 (스크롤 하단 추가 로딩) | `CommonLoadingIndicator` (스피너) |
+| 버튼 내 로딩 | `CommonLoadingIndicator` (스피너, 흰색) |
+| 이미지 업로드/인라인 액션 | `CommonLoadingIndicator` (스피너) |
+
+---
+
+## 아키텍처
+
+### 공통 스피너 위젯 (신규)
+
+**`lib/widgets/common/loading_indicator.dart`**
+
+- `CircularProgressIndicator`를 래핑하는 `CommonLoadingIndicator` 위젯
+- 기본 색상: `AppColors.primaryYellow`
+- 버튼 내부용 흰색 variant: `CommonLoadingIndicator.white()` (색상: `AppColors.textColorWhite`, 어두운 배경 버튼에서 사용)
+- strokeWidth: 2.0 고정
+- 33개 파일의 직접 사용을 이 위젯으로 교체
+
+### 스켈레톤 위젯 (신규 5개)
+
+기존 3개(`RegisterTabSkeletonSliver`, `ChatRoomListSkeletonSliver`, `RegisterInputFormSkeleton`)는 유지.
+
+신규 추가:
+
+| 파일 | 사용 화면 |
+|------|----------|
+| `lib/widgets/skeletons/home_feed_skeleton.dart` | 홈 피드 (`home_tab_screen.dart`) |
+| `lib/widgets/skeletons/item_detail_skeleton.dart` | 물품 상세 (`item_detail_description_screen.dart`) |
+| `lib/widgets/skeletons/my_like_list_skeleton.dart` | 찜 목록 (`my_like_list_screen.dart`) |
+| `lib/widgets/skeletons/notification_settings_skeleton.dart` | 알림 설정 (`notification_settings_screen.dart`) |
+| `lib/widgets/skeletons/trade_partner_select_skeleton.dart` | 거래 파트너 선택 (`trade_complete_partner_select_screen.dart`) |
+
+---
+
+## 스켈레톤 설계 원칙
+
+토스 스타일 심플 스켈레톤. 아래 3가지만 지킨다.
+
+1. **라인 2~3개만** — 실제 텍스트 줄 수와 동일하게. 더 많으면 촌스러워짐
+2. **너비 변화** — 첫 줄 50~65%, 둘째 줄 35~75% 식으로 다르게. 전부 100%는 금지
+3. **실제 UI 비율** — 이미지 높이, 원형 크기를 실제 위젯과 맞춤. 로딩 완료 후 레이아웃 점프 방지
+
+**shimmer 설정 (전 스켈레톤 공통):**
+```dart
+effect: const ShimmerEffect(
+  baseColor: AppColors.opacity10White,
+  highlightColor: AppColors.opacity30White,
+)
+```
+패키지: `skeletonizer ^2.1.0+1` (추가 패키지 없음)
+
+---
+
+## 화면별 스켈레톤 상세
+
+### ① 홈 피드 (`HomeFeedSkeletonSliver`)
+- SliverGrid 2열 구조
+- 각 카드: 이미지 영역(130h) + 제목 라인(65% 너비) + 가격 라인(45% 너비)
+- 태그(상태, 거래방식)는 스켈레톤에서 생략
+
+### ② 물품 상세 (`ItemDetailSkeleton`)
+- 이미지 전체 너비 (300h)
+- 프로필 원형(40×40) + 닉네임/위치 2줄
+- 제목(70%) + 가격(40%)
+- 설명 텍스트 3줄 (100% / 85% / 60%)
+
+### ③ 찜 목록 (`MyLikeListSkeletonSliver`)
+- SliverList 구조
+- 각 아이템: 썸네일 정사각형(64×64, radius 10) + 텍스트 3줄
+
+### ④ 알림 설정 (`NotificationSettingsSkeleton`)
+- 일반 ListView 구조
+- 각 아이템: 원형 프로필(44×44) + 텍스트 2줄 + 토글 자리
+
+### ⑤ 거래 파트너 선택 (`TradePartnerSelectSkeletonSliver`)
+- SliverList 구조
+- 각 아이템: 원형 프로필(44×44) + 이름/위치 2줄 + 버튼 자리(60×30, radius 8)
+
+---
+
+## 교체 범위
+
+### CircularProgressIndicator → CommonLoadingIndicator
+전체 33개 파일. 주요 대상:
+
+- `lib/screens/home_tab_screen.dart` (페이징 로딩)
+- `lib/screens/register_tab_screen.dart`
+- `lib/screens/item_modification_screen.dart`
+- `lib/screens/notification_settings_screen.dart`
+- `lib/screens/chat_room_screen.dart`
+- `lib/widgets/login_button.dart`
+- `lib/widgets/common/cached_image.dart`
+- `lib/widgets/common/completion_button.dart`
+- `lib/widgets/chat_message_item.dart`
+- `lib/widgets/chat_image_bubble.dart`
+- 그 외 24개 파일
+
+### 초기 로딩 교체 (스피너 → 스켈레톤)
+- `home_tab_screen.dart`: `_isLoading && _feedItems.isEmpty` 분기에서 스켈레톤으로 교체
+- `item_detail_description_screen.dart`: 초기 로딩 스피너 → 스켈레톤
+- `my_like_list_screen.dart`: 초기 로딩 스피너 → 스켈레톤
+- `notification_settings_screen.dart`: 초기 로딩 스피너 → 스켈레톤
+- `trade_complete_partner_select_screen.dart`: 초기 로딩 스피너 → 스켈레톤
+
+---
+
+## 변경하지 않는 것
+
+- 기존 3개 스켈레톤 (`RegisterTabSkeletonSliver`, `ChatRoomListSkeletonSliver`, `RegisterInputFormSkeleton`) — 이미 잘 동작 중
+- 페이징 로딩 (`_isLoadingMore`) — 스피너 유지. 스크롤 하단 로딩에는 스켈레톤 불필요
+- `skeletonizer` 패키지 버전 — 유지

--- a/lib/screens/chat_location_picker_screen.dart
+++ b/lib/screens/chat_location_picker_screen.dart
@@ -11,6 +11,7 @@ import 'package:romrom_fe/utils/location_utils.dart';
 import 'package:romrom_fe/utils/device_type.dart';
 import 'package:romrom_fe/widgets/common/completion_button.dart';
 import 'package:romrom_fe/widgets/common/current_location_button.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
 import 'package:shadex/shadex.dart';
 
@@ -97,7 +98,7 @@ class _ChatLocationPickerScreenState extends State<ChatLocationPickerScreen> {
                 // 네이버 지도
                 Positioned.fill(
                   child: _currentPosition == null
-                      ? const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow))
+                      ? const Center(child: CommonLoadingIndicator())
                       : NaverMap(
                           options: NaverMapViewOptions(
                             initialCameraPosition: NCameraPosition(target: _currentPosition!, zoom: 15),

--- a/lib/screens/chat_room_screen.dart
+++ b/lib/screens/chat_room_screen.dart
@@ -26,6 +26,7 @@ import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/chat_input_bar.dart';
 import 'package:romrom_fe/widgets/chat_message_item.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/chat_room_app_bar.dart';
 import 'package:romrom_fe/widgets/chat_trade_info_card.dart';
 import 'package:romrom_fe/widgets/common/exchange_request_bottom_sheet.dart';
@@ -734,7 +735,7 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> with WidgetsBindingObse
     if (_isLoading) {
       return const Scaffold(
         backgroundColor: AppColors.primaryBlack,
-        body: Center(child: CircularProgressIndicator(color: AppColors.primaryYellow)),
+        body: Center(child: CommonLoadingIndicator()),
       );
     }
 

--- a/lib/screens/chat_tab_screen.dart
+++ b/lib/screens/chat_tab_screen.dart
@@ -14,6 +14,7 @@ import 'package:romrom_fe/services/member_manager_service.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/widgets/chat_room_list_item.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common/triple_toggle_switch.dart';
 import 'package:romrom_fe/widgets/skeletons/chat_room_list_skeleton.dart';
 import 'package:romrom_fe/screens/profile/member_profile_screen.dart';
@@ -386,9 +387,8 @@ class _ChatTabScreenState extends State<ChatTabScreen> with TickerProviderStateM
               SliverToBoxAdapter(
                 child: Padding(
                   padding: EdgeInsets.symmetric(vertical: 20.h),
-                  child: const Center(
-                    child: SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2)),
-                  ),
+                  // 무한 스크롤 추가 로딩 인디케이터
+                  child: const Center(child: CommonLoadingIndicator()),
                 ),
               ),
           ],

--- a/lib/screens/home_tab_screen.dart
+++ b/lib/screens/home_tab_screen.dart
@@ -38,6 +38,8 @@ import 'package:romrom_fe/screens/report_screen.dart';
 import 'package:romrom_fe/screens/item_register_screen.dart';
 import 'package:romrom_fe/screens/trade_request_screen.dart';
 import 'package:romrom_fe/widgets/coach_mark/coach_mark_overlay.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
+import 'package:romrom_fe/widgets/skeletons/home_feed_skeleton.dart';
 
 /// 홈 탭 화면
 class HomeTabScreen extends StatefulWidget {
@@ -528,7 +530,7 @@ class _HomeTabScreenState extends State<HomeTabScreen> {
   @override
   Widget build(BuildContext context) {
     if (_isLoading) {
-      return const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow, strokeWidth: 2));
+      return const HomeFeedSkeleton();
     }
     return _buildContent();
   }
@@ -593,7 +595,7 @@ class _HomeTabScreenState extends State<HomeTabScreen> {
               itemBuilder: (context, index) {
                 // 로딩 인디케이터 (맨 끝)
                 if (index >= _virtualItemCount) {
-                  return const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow));
+                  return const Center(child: CommonLoadingIndicator());
                 }
                 // 광고 슬롯
                 if (_isAdAtVirtualIndex(index)) {

--- a/lib/screens/item_detail_description_screen.dart
+++ b/lib/screens/item_detail_description_screen.dart
@@ -44,6 +44,8 @@ import 'package:romrom_fe/screens/chat_room_screen.dart';
 import 'package:romrom_fe/screens/profile/member_profile_screen.dart';
 import 'package:romrom_fe/screens/trade_location_detail_screen.dart';
 import 'package:romrom_fe/screens/trade_request_screen.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
+import 'package:romrom_fe/widgets/skeletons/item_detail_skeleton.dart';
 
 class ItemDetailDescriptionScreen extends StatefulWidget {
   final String itemId;
@@ -325,10 +327,7 @@ class _ItemDetailDescriptionScreenState extends State<ItemDetailDescriptionScree
   @override
   Widget build(BuildContext context) {
     if (isLoading) {
-      return const Scaffold(
-        backgroundColor: AppColors.primaryBlack,
-        body: Center(child: CircularProgressIndicator(color: AppColors.primaryYellow)),
-      );
+      return const Scaffold(backgroundColor: AppColors.primaryBlack, body: ItemDetailSkeleton());
     }
 
     // 작성자가 탈퇴한 게시글인 경우 별도 화면 표시
@@ -456,13 +455,7 @@ class _ItemDetailDescriptionScreenState extends State<ItemDetailDescriptionScree
                               },
 
                               // 로딩 인디케이터
-                              placeholder: (ctx, url) => const Center(
-                                child: SizedBox(
-                                  width: 32,
-                                  height: 32,
-                                  child: CircularProgressIndicator(strokeWidth: 3, color: AppColors.primaryYellow),
-                                ),
-                              ),
+                              placeholder: (ctx, url) => const Center(child: CommonLoadingIndicator(size: 32.0)),
 
                               // 이미지 없음/로딩 실패 시
                               errorWidget: (ctx, url, err) =>

--- a/lib/screens/item_modification_screen.dart
+++ b/lib/screens/item_modification_screen.dart
@@ -3,9 +3,9 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:romrom_fe/enums/snack_bar_type.dart';
 import 'package:romrom_fe/models/apis/objects/item.dart';
 import 'package:romrom_fe/models/apis/requests/item_request.dart';
-import 'package:romrom_fe/models/app_colors.dart';
 import 'package:romrom_fe/services/apis/item_api.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
 import 'package:romrom_fe/widgets/register_input_form.dart';
 
@@ -70,7 +70,7 @@ class _ItemModificationScreenState extends State<ItemModificationScreen> {
           showBottomBorder: true,
         ),
         body: _isLoading
-            ? const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow))
+            ? const Center(child: CommonLoadingIndicator())
             : SingleChildScrollView(
                 padding: EdgeInsets.only(top: 24.h, bottom: 24.h, left: 24.w),
                 child: RegisterInputForm(

--- a/lib/screens/item_register_location_screen.dart
+++ b/lib/screens/item_register_location_screen.dart
@@ -10,6 +10,7 @@ import 'package:romrom_fe/services/location_service.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/completion_button.dart';
 import 'package:romrom_fe/widgets/common/current_location_button.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
 import 'package:romrom_fe/widgets/onboarding_title_header.dart';
 import 'package:shadex/shadex.dart';
@@ -103,7 +104,7 @@ class _ItemRegisterLocationScreenState extends State<ItemRegisterLocationScreen>
                 // 네이버 지도 전체 채우기
                 Positioned.fill(
                   child: _currentPosition == null
-                      ? const Center(child: CircularProgressIndicator())
+                      ? const Center(child: CommonLoadingIndicator())
                       : NaverMap(
                           options: NaverMapViewOptions(
                             initialCameraPosition: NCameraPosition(target: _currentPosition!, zoom: 15),

--- a/lib/screens/my_page/block_management_screen.dart
+++ b/lib/screens/my_page/block_management_screen.dart
@@ -9,6 +9,7 @@ import 'package:romrom_fe/screens/profile/member_profile_screen.dart';
 import 'package:romrom_fe/services/apis/member_api.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
 import 'package:romrom_fe/widgets/user_profile_circular_avatar.dart';
 
@@ -92,7 +93,7 @@ class _BlockManagementScreenState extends State<BlockManagementScreen> {
       backgroundColor: AppColors.primaryBlack,
       appBar: CommonAppBar(title: '차단 관리', showBottomBorder: false, onBackPressed: () => Navigator.pop(context)),
       body: _isLoading
-          ? const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow))
+          ? const Center(child: CommonLoadingIndicator())
           : _blockedMembers.isEmpty
           ? _buildEmptyState()
           : _buildBlockedMembersList(),

--- a/lib/screens/my_page/my_category_settings_screen.dart
+++ b/lib/screens/my_page/my_category_settings_screen.dart
@@ -7,6 +7,7 @@ import 'package:romrom_fe/services/apis/member_api.dart';
 import 'package:romrom_fe/widgets/common/category_chip.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/completion_button.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
 
 /// 선호 카테고리 설정 화면
@@ -68,7 +69,7 @@ class _MyCategorySettingsScreenState extends State<MyCategorySettingsScreen> {
       backgroundColor: AppColors.primaryBlack,
       appBar: CommonAppBar(title: '선호 카테고리 설정', showBottomBorder: true, onBackPressed: () => Navigator.pop(context)),
       body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
+          ? const Center(child: CommonLoadingIndicator())
           : Stack(
               children: [
                 Padding(

--- a/lib/screens/my_page/my_like_list_screen.dart
+++ b/lib/screens/my_page/my_like_list_screen.dart
@@ -23,6 +23,8 @@ import 'package:romrom_fe/widgets/item_detail_condition_tag.dart';
 import 'package:romrom_fe/widgets/item_detail_trade_option_tag.dart';
 import 'package:romrom_fe/widgets/common/cached_image.dart';
 import 'package:romrom_fe/widgets/common/empty_state_view.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
+import 'package:romrom_fe/widgets/skeletons/my_like_list_skeleton.dart';
 
 class MyLikeListScreen extends StatefulWidget {
   const MyLikeListScreen({super.key});
@@ -159,7 +161,7 @@ class _MyLikeListScreenState extends State<MyLikeListScreen> {
       backgroundColor: AppColors.primaryBlack,
       appBar: CommonAppBar(title: '좋아요 목록', showBottomBorder: true, onBackPressed: () => Navigator.pop(context)),
       body: _items.isEmpty && _isLoading
-          ? const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow))
+          ? const Padding(padding: EdgeInsets.symmetric(horizontal: 24), child: MyLikeListSkeleton())
           : _items.isEmpty && !_isLoading
           ? EmptyStateView(
               icon: AppIcons.profilelikecount,
@@ -179,15 +181,9 @@ class _MyLikeListScreenState extends State<MyLikeListScreen> {
                 itemBuilder: (context, index) {
                   // ... 기존 itemBuilder 코드 동일
                   if (_hasMoreItems && index == _items.length) {
-                    return Padding(
-                      padding: EdgeInsets.symmetric(vertical: 16.h),
-                      child: const Center(
-                        child: SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator(color: AppColors.primaryYellow),
-                        ),
-                      ),
+                    return const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 16),
+                      child: Center(child: CommonLoadingIndicator(size: 20)),
                     );
                   }
                   final item = _items[index];

--- a/lib/screens/my_page/my_profile_edit_screen.dart
+++ b/lib/screens/my_page/my_profile_edit_screen.dart
@@ -12,6 +12,7 @@ import 'package:romrom_fe/services/apis/member_api.dart';
 import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/common_modal.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
 import 'package:romrom_fe/widgets/profile_sections.dart';
 import 'package:romrom_fe/widgets/user_profile_circular_avatar.dart';
@@ -262,7 +263,8 @@ class _MyProfileEditScreenState extends State<MyProfileEditScreen> {
                     shape: BoxShape.circle,
                     border: Border.all(color: AppColors.textColorWhite, width: 1.w),
                   ),
-                  child: const CircularProgressIndicator(color: AppColors.primaryYellow),
+                  // 이미지 업로드 중 스피너
+                  child: const CommonLoadingIndicator(),
                 )
               : UserProfileCircularAvatar(
                   avatarSize: Size(132.w, 132.h),

--- a/lib/screens/my_page/terms_screen.dart
+++ b/lib/screens/my_page/terms_screen.dart
@@ -4,6 +4,7 @@ import 'package:romrom_fe/enums/term_type.dart';
 import 'package:romrom_fe/models/app_colors.dart';
 import 'package:romrom_fe/models/app_theme.dart';
 import 'package:romrom_fe/models/term_contents.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
 
 /// 이용약관 화면
@@ -53,7 +54,7 @@ class _TermsScreenState extends State<TermsScreen> {
       backgroundColor: AppColors.primaryBlack,
       appBar: CommonAppBar(title: '이용 약관', showBottomBorder: true, onBackPressed: () => Navigator.pop(context)),
       body: _isLoading
-          ? const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow))
+          ? const Center(child: CommonLoadingIndicator())
           : SingleChildScrollView(
               padding: EdgeInsets.symmetric(horizontal: 24.w),
               child: Column(

--- a/lib/screens/notification_screen.dart
+++ b/lib/screens/notification_screen.dart
@@ -19,6 +19,7 @@ import 'package:romrom_fe/widgets/common/common_modal.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/app_pressable.dart';
 import 'package:romrom_fe/widgets/common/glass_header_delegate.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/notification_item_widget.dart';
 import 'package:romrom_fe/widgets/common/app_fade_slide_in.dart';
 import 'package:romrom_fe/widgets/common/app_skeleton.dart';
@@ -452,7 +453,14 @@ class _NotificationScreenState extends State<NotificationScreen>
   Widget _buildNotificationList() {
     final notifications = _isRightSelected ? _romromNotifications : _activityNotifications;
 
-    if (notifications.isEmpty && !_isLoading) {
+    if (_isLoading) {
+      return SizedBox(
+        height: 300.h,
+        child: const Center(child: CommonLoadingIndicator()),
+      );
+    }
+
+    if (notifications.isEmpty) {
       return AppFadeSlideIn(
         child: Container(
           height: 300.h,

--- a/lib/screens/notification_settings_screen.dart
+++ b/lib/screens/notification_settings_screen.dart
@@ -9,6 +9,7 @@ import 'package:romrom_fe/services/notification_permission_service.dart';
 import 'package:romrom_fe/widgets/common/common_modal.dart';
 import 'package:romrom_fe/widgets/common/completed_toggle_switch.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
+import 'package:romrom_fe/widgets/skeletons/notification_settings_skeleton.dart';
 
 /// 알림 설정 화면
 class NotificationSettingsScreen extends StatefulWidget {
@@ -126,7 +127,7 @@ class _NotificationSettingsScreenState extends State<NotificationSettingsScreen>
       backgroundColor: AppColors.primaryBlack,
       appBar: CommonAppBar(title: '설정', onBackPressed: () => Navigator.pop(context)),
       body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
+          ? const NotificationSettingsSkeleton()
           : SingleChildScrollView(
               child: Padding(
                 padding: EdgeInsets.fromLTRB(24.w, 16.h, 24.w, 24.h),

--- a/lib/screens/onboarding/term_agreement_step.dart
+++ b/lib/screens/onboarding/term_agreement_step.dart
@@ -13,6 +13,7 @@ import 'package:romrom_fe/services/apis/member_api.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/completion_button.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 
 class TermAgreementStep extends StatefulWidget {
   final VoidCallback onNext;
@@ -114,7 +115,7 @@ class _TermAgreementStepState extends State<TermAgreementStep> {
   @override
   Widget build(BuildContext context) {
     if (_isLoading) {
-      return const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow));
+      return const Center(child: CommonLoadingIndicator());
     }
 
     return Padding(

--- a/lib/screens/profile/member_profile_screen.dart
+++ b/lib/screens/profile/member_profile_screen.dart
@@ -12,6 +12,7 @@ import 'package:romrom_fe/services/apis/member_api.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/widgets/common/common_modal.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common/romrom_context_menu.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
 import 'package:romrom_fe/widgets/profile_sections.dart';
@@ -192,7 +193,7 @@ class _MemberProfileScreenState extends State<MemberProfileScreen> {
     if (_isLoading) {
       return const Scaffold(
         backgroundColor: AppColors.primaryBlack,
-        body: Center(child: CircularProgressIndicator(color: AppColors.primaryYellow)),
+        body: Center(child: CommonLoadingIndicator()),
       );
     }
 

--- a/lib/screens/register_tab_screen.dart
+++ b/lib/screens/register_tab_screen.dart
@@ -19,6 +19,7 @@ import 'package:romrom_fe/widgets/common/romrom_context_menu.dart';
 import 'package:romrom_fe/widgets/common/error_image_placeholder.dart';
 import 'package:romrom_fe/widgets/common/cached_image.dart';
 import 'package:romrom_fe/widgets/common/app_pressable.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common/trade_status_tag.dart';
 import 'package:romrom_fe/widgets/skeletons/register_tab_skeleton.dart';
 import 'package:romrom_fe/widgets/common/glass_header_delegate.dart';
@@ -367,7 +368,7 @@ class _RegisterTabScreenState extends State<RegisterTabScreen> with TickerProvid
         SliverToBoxAdapter(
           child: Padding(
             padding: EdgeInsets.symmetric(vertical: 16.h),
-            child: const Center(child: CircularProgressIndicator()),
+            child: const Center(child: CommonLoadingIndicator()),
           ),
         ),
       // 하단 여백 24px

--- a/lib/screens/request_management_tab_screen.dart
+++ b/lib/screens/request_management_tab_screen.dart
@@ -24,6 +24,7 @@ import 'package:romrom_fe/services/apis/trade_api.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/completed_toggle_switch.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common/glass_header_delegate.dart';
 import 'package:romrom_fe/widgets/request_list_item_card_widget.dart';
 import 'package:romrom_fe/widgets/request_management_item_card_widget.dart';
@@ -291,10 +292,7 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
     // 보낸 요청은 필터링 없이 모든 요청 표시
     if (_sentRequests.isEmpty) {
       return _isLoading
-          ? const SizedBox(
-              height: 500,
-              child: Center(child: CircularProgressIndicator(color: AppColors.primaryYellow, strokeWidth: 2)),
-            )
+          ? const SizedBox(height: 500, child: Center(child: CommonLoadingIndicator()))
           : Container(
               height: 200,
               padding: EdgeInsets.symmetric(horizontal: 24.w),
@@ -568,10 +566,7 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
   Widget _buildItemCardsCarousel() {
     if (_itemCards.isEmpty) {
       return _isLoading
-          ? const SizedBox(
-              height: 150,
-              child: Center(child: CircularProgressIndicator(color: AppColors.primaryYellow, strokeWidth: 2)),
-            )
+          ? const SizedBox(height: 150, child: Center(child: CommonLoadingIndicator()))
           : Container(
               height: 326,
               padding: EdgeInsets.symmetric(horizontal: 24.w),
@@ -725,10 +720,7 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
 
     if (filteredRequests.isEmpty) {
       return _isLoading
-          ? const SizedBox(
-              height: 150,
-              child: Center(child: CircularProgressIndicator(color: AppColors.primaryYellow, strokeWidth: 2)),
-            )
+          ? const SizedBox(height: 150, child: Center(child: CommonLoadingIndicator()))
           : Container(
               height: 200,
               padding: EdgeInsets.symmetric(horizontal: 24.w),
@@ -742,10 +734,7 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
     }
 
     return _isLoading
-        ? const SizedBox(
-            height: 150,
-            child: Center(child: CircularProgressIndicator(color: AppColors.primaryYellow, strokeWidth: 2)),
-          )
+        ? const SizedBox(height: 150, child: Center(child: CommonLoadingIndicator()))
         : Padding(
             padding: EdgeInsets.symmetric(horizontal: 24.w),
             child: Column(

--- a/lib/screens/search_range_setting_screen.dart
+++ b/lib/screens/search_range_setting_screen.dart
@@ -11,6 +11,7 @@ import 'package:romrom_fe/services/apis/member_api.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/current_location_button.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common/range_slider_widget.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
 
@@ -72,7 +73,7 @@ class _SearchRangeSettingScreenState extends State<SearchRangeSettingScreen> {
       body: _locationNotSet
           ? _buildLocationNotSetView()
           : _currentPosition == null
-          ? const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow))
+          ? const Center(child: CommonLoadingIndicator())
           : Column(
               children: [
                 Expanded(child: _buildMapSection()),

--- a/lib/screens/trade_complete_partner_select_screen.dart
+++ b/lib/screens/trade_complete_partner_select_screen.dart
@@ -14,6 +14,7 @@ import 'package:romrom_fe/widgets/common/completion_button.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
 import 'package:romrom_fe/widgets/trade_request_target_preview.dart';
 import 'package:romrom_fe/widgets/user_profile_circular_avatar.dart';
+import 'package:romrom_fe/widgets/skeletons/trade_partner_select_skeleton.dart';
 
 /// 교환 완료 처리 시 교환 상대를 선택하는 화면
 class TradeCompletePartnerSelectScreen extends StatefulWidget {
@@ -75,7 +76,7 @@ class _TradeCompletePartnerSelectScreenState extends State<TradeCompletePartnerS
         children: [
           Expanded(
             child: _isLoading
-                ? const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow))
+                ? const TradePartnerSelectSkeleton()
                 : ListView(
                     children: [
                       _buildItemCard(),

--- a/lib/screens/trade_request_screen.dart
+++ b/lib/screens/trade_request_screen.dart
@@ -18,6 +18,7 @@ import 'package:romrom_fe/utils/item_label_utils.dart';
 import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/common_modal.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common/custom_floating_button.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
 import 'package:romrom_fe/widgets/request_management_item_card_widget.dart';
@@ -264,7 +265,7 @@ class _TradeRequestScreenState extends State<TradeRequestScreen> {
 
                 Expanded(
                   child: _isLoading
-                      ? const Center(child: CircularProgressIndicator(color: AppColors.primaryYellow))
+                      ? const Center(child: CommonLoadingIndicator())
                       : _myItemCards.isEmpty
                       ? _buildEmptyState()
                       : _buildTradeRequestStep(),
@@ -447,12 +448,9 @@ class _TradeRequestScreenState extends State<TradeRequestScreen> {
                       highlightColor: requestButtonHighlightColor,
                       splashColor: requestButtonSplashColor,
                       child: Center(
+                        // 요청 중이면 검정 스피너, 아니면 버튼 텍스트
                         child: (_isSubmitting || _isCheckingExistence)
-                            ? SizedBox(
-                                width: 24.w,
-                                height: 24.h,
-                                child: const CircularProgressIndicator(color: AppColors.textColorBlack, strokeWidth: 2),
-                              )
+                            ? const CommonLoadingIndicator(color: AppColors.textColorBlack)
                             : Text('요청하기', style: CustomTextStyles.p1.copyWith(color: AppColors.textColorBlack)),
                       ),
                     ),

--- a/lib/widgets/chat_image_bubble.dart
+++ b/lib/widgets/chat_image_bubble.dart
@@ -5,6 +5,7 @@ import 'package:photo_viewer/photo_viewer.dart';
 import 'package:romrom_fe/models/apis/objects/chat_message.dart';
 import 'package:romrom_fe/models/app_colors.dart';
 import 'package:romrom_fe/widgets/common/error_image_placeholder.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 
 double _gapBase = 2.0;
 
@@ -151,9 +152,8 @@ Widget chatImageBubble(BuildContext context, ChatMessage message) {
           fadeInDuration: Duration.zero,
           fadeOutDuration: Duration.zero,
           placeholderFadeInDuration: Duration.zero,
-          placeholder: (_, _) => const Center(
-            child: SizedBox(width: 32, height: 32, child: CircularProgressIndicator(color: AppColors.primaryYellow)),
-          ),
+          // 이미지 로딩 중 스피너
+          placeholder: (_, _) => const Center(child: CommonLoadingIndicator(size: 32.0)),
           errorWidget: (_, _, _) => const Center(child: ErrorImagePlaceholder()),
         );
       }).toList(),
@@ -171,11 +171,10 @@ Widget chatImageBubble(BuildContext context, ChatMessage message) {
         fadeInDuration: Duration.zero,
         fadeOutDuration: Duration.zero,
         placeholderFadeInDuration: Duration.zero,
+        // 셀 이미지 로딩 중 스피너
         placeholder: (_, _) => const ColoredBox(
           color: AppColors.opacity10White,
-          child: Center(
-            child: SizedBox(width: 24, height: 24, child: CircularProgressIndicator(color: AppColors.primaryYellow)),
-          ),
+          child: Center(child: CommonLoadingIndicator()),
         ),
         errorWidget: (_, _, _) => const Center(child: ErrorImagePlaceholder()),
       ),

--- a/lib/widgets/chat_location_bubble.dart
+++ b/lib/widgets/chat_location_bubble.dart
@@ -11,6 +11,7 @@ import 'package:romrom_fe/models/app_theme.dart';
 import 'package:romrom_fe/models/app_urls.dart';
 import 'package:romrom_fe/models/location_address.dart';
 import 'package:romrom_fe/services/location_service.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/utils/location_utils.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -160,13 +161,8 @@ class _ChatLocationBubbleState extends State<ChatLocationBubble> {
     if (_mapImageBytes == null) {
       return Container(
         color: AppColors.secondaryBlack2,
-        child: const Center(
-          child: SizedBox(
-            width: 20,
-            height: 20,
-            child: CircularProgressIndicator(strokeWidth: 2, color: AppColors.primaryYellow),
-          ),
-        ),
+        // 지도 이미지 로딩 중 스피너
+        child: const Center(child: CommonLoadingIndicator()),
       );
     }
     return Image.memory(_mapImageBytes!, width: width, height: 176.h, fit: BoxFit.cover);

--- a/lib/widgets/chat_message_item.dart
+++ b/lib/widgets/chat_message_item.dart
@@ -8,6 +8,7 @@ import 'package:romrom_fe/models/app_theme.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/widgets/chat_image_bubble.dart';
 import 'package:romrom_fe/widgets/chat_location_bubble.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 
 /// 채팅 메시지 아이템 위젯
 /// system / text / image (업로드 중 포함) / 거래 완료 시스템 메시지 모든 타입 처리
@@ -319,13 +320,8 @@ class ChatMessageItem extends StatelessWidget {
             Positioned.fill(
               child: ColoredBox(
                 color: AppColors.primaryBlack.withValues(alpha: 0.5),
-                child: const Center(
-                  child: SizedBox(
-                    width: 32,
-                    height: 32,
-                    child: CircularProgressIndicator(color: AppColors.primaryYellow),
-                  ),
-                ),
+                // 이미지 업로드 중 오버레이 스피너
+                child: const Center(child: CommonLoadingIndicator(size: 32.0)),
               ),
             ),
           ],

--- a/lib/widgets/common/cached_image.dart
+++ b/lib/widgets/common/cached_image.dart
@@ -1,8 +1,8 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:romrom_fe/icons/app_icons.dart';
 import 'package:romrom_fe/models/app_colors.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 
 /// 캐싱이 적용된 네트워크 이미지 위젯
 ///
@@ -61,13 +61,8 @@ class CachedImage extends StatelessWidget {
       width: width,
       height: height,
       color: AppColors.secondaryBlack1,
-      child: Center(
-        child: SizedBox(
-          width: 20.w,
-          height: 20.w,
-          child: const CircularProgressIndicator(strokeWidth: 2, color: AppColors.opacity40White),
-        ),
-      ),
+      // 이미지 로딩 중 스피너 표시
+      child: const Center(child: CommonLoadingIndicator(color: AppColors.opacity40White, size: 20.0)),
     );
   }
 

--- a/lib/widgets/common/cached_image.dart
+++ b/lib/widgets/common/cached_image.dart
@@ -2,7 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:romrom_fe/icons/app_icons.dart';
 import 'package:romrom_fe/models/app_colors.dart';
-import 'package:romrom_fe/widgets/common/loading_indicator.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 /// 캐싱이 적용된 네트워크 이미지 위젯
 ///
@@ -55,14 +55,12 @@ class CachedImage extends StatelessWidget {
     return image;
   }
 
-  /// 기본 로딩 플레이스홀더
+  /// 기본 로딩 플레이스홀더 — shimmer 효과
   Widget _buildDefaultPlaceholder() {
-    return Container(
-      width: width,
-      height: height,
-      color: AppColors.secondaryBlack1,
-      // 이미지 로딩 중 스피너 표시
-      child: const Center(child: CommonLoadingIndicator(color: AppColors.opacity40White, size: 20.0)),
+    return Skeletonizer(
+      enabled: true,
+      effect: const ShimmerEffect(baseColor: AppColors.opacity10White, highlightColor: AppColors.opacity30White),
+      child: Container(width: width, height: height, color: AppColors.secondaryBlack1),
     );
   }
 

--- a/lib/widgets/common/completion_button.dart
+++ b/lib/widgets/common/completion_button.dart
@@ -4,6 +4,7 @@ import 'package:romrom_fe/models/app_colors.dart';
 import 'package:romrom_fe/models/app_theme.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/widgets/common/app_pressable.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 
 class CompletionButton extends StatelessWidget {
   final bool isEnabled; // 버튼 활성화
@@ -70,15 +71,9 @@ class CompletionButton extends StatelessWidget {
             color: backgroundColor,
             borderRadius: BorderRadius.circular(10.r),
             child: Center(
+              // 로딩 중이면 흰색 스피너, 아니면 버튼 텍스트
               child: isLoading
-                  ? SizedBox(
-                      width: 24.w,
-                      height: 24.h,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2.w,
-                        valueColor: const AlwaysStoppedAnimation<Color>(AppColors.textColorWhite),
-                      ),
-                    )
+                  ? const CommonLoadingIndicator.white()
                   : Text(buttonText, style: buttonTextStyle, textAlign: TextAlign.center, softWrap: false),
             ),
           ),

--- a/lib/widgets/common/loading_indicator.dart
+++ b/lib/widgets/common/loading_indicator.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:romrom_fe/models/app_colors.dart';
+
+/// 앱 전역 공통 로딩 스피너. CircularProgressIndicator 직접 사용 금지 — 이 위젯 사용.
+class CommonLoadingIndicator extends StatelessWidget {
+  const CommonLoadingIndicator({super.key, this.color = AppColors.primaryYellow, this.size = 24.0});
+
+  /// 버튼 내부 흰색 스피너용 named constructor
+  const CommonLoadingIndicator.white({super.key, this.size = 18.0}) : color = AppColors.textColorWhite;
+
+  final Color color;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: size,
+      height: size,
+      child: CircularProgressIndicator(strokeWidth: 2.0, valueColor: AlwaysStoppedAnimation<Color>(color)),
+    );
+  }
+}

--- a/lib/widgets/item_card_option_chip.dart
+++ b/lib/widgets/item_card_option_chip.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:romrom_fe/enums/item_trade_option.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/utils/item_card_scale_utils.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import '../models/app_colors.dart';
 import '../models/app_theme.dart';
 
@@ -71,12 +72,13 @@ class ItemCardOptionChip extends ConsumerWidget {
           ),
         );
       },
+      // 칩 상태 로딩 중 표시
       loading: () => Container(
         width: 72,
         height: 29,
         alignment: Alignment.center,
         decoration: buildBoxDecoration(AppColors.itemCardOptionChip, BorderRadius.circular(100)),
-        child: const CircularProgressIndicator(strokeWidth: 2),
+        child: const CommonLoadingIndicator(size: 16.0),
       ),
       error: (err, stack) => Container(
         width: 72,

--- a/lib/widgets/login_button.dart
+++ b/lib/widgets/login_button.dart
@@ -23,6 +23,7 @@ import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/widgets/common/common_modal.dart';
 import 'package:romrom_fe/widgets/common/app_pressable.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// 로그인 버튼
@@ -53,7 +54,8 @@ class _LoginButtonState extends State<LoginButton> {
       barrierColor: AppColors.opacity50Black,
       builder: (_) => const PopScope(
         canPop: false,
-        child: Center(child: CircularProgressIndicator(color: AppColors.primaryYellow)),
+        // 로그인 처리 중 전체화면 오버레이 스피너
+        child: Center(child: CommonLoadingIndicator()),
       ),
     );
 

--- a/lib/widgets/native_ad_widget.dart
+++ b/lib/widgets/native_ad_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:romrom_fe/models/app_colors.dart';
 import 'package:romrom_fe/services/ad_mob_service.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 
 /// 홈 피드용 네이티브 광고 위젯
 /// PageView 한 페이지를 채우는 전체화면 크기로 표시됨
@@ -64,9 +65,10 @@ class _NativeAdWidgetState extends State<NativeAdWidget> {
   @override
   Widget build(BuildContext context) {
     if (!_isLoaded || _nativeAd == null) {
+      // 광고 로드 전 로딩 스피너 표시
       return const ColoredBox(
         color: AppColors.primaryBlack,
-        child: Center(child: CircularProgressIndicator(color: AppColors.primaryYellow)),
+        child: Center(child: CommonLoadingIndicator()),
       );
     }
 

--- a/lib/widgets/register_input_form.dart
+++ b/lib/widgets/register_input_form.dart
@@ -30,6 +30,7 @@ import 'package:romrom_fe/widgets/common/common_modal.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/completion_button.dart';
 import 'package:romrom_fe/widgets/common/gradient_text.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/register_option_chip.dart';
 import 'package:romrom_fe/widgets/register_text_field.dart';
 import 'package:romrom_fe/widgets/skeletons/register_input_form_skeleton.dart';
@@ -835,19 +836,9 @@ class _RegisterInputFormState extends State<RegisterInputForm> {
                   focusNode: _priceFocusNode,
                   textInputAction: TextInputAction.done,
                   onFieldSubmitted: (_) => FocusManager.instance.primaryFocus?.unfocus(),
-                  // 로딩 중일 때 suffixIcon으로 스피너 표시
+                  // AI 가격 예측 로딩 중 suffixIcon 스피너 표시
                   suffixIcon: _isAiPriceLoading
-                      ? Padding(
-                          padding: EdgeInsets.all(12.w),
-                          child: SizedBox(
-                            width: 10.w,
-                            height: 10.w,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2.w,
-                              valueColor: const AlwaysStoppedAnimation<Color>(AppColors.primaryYellow),
-                            ),
-                          ),
-                        )
+                      ? const Padding(padding: EdgeInsets.all(12), child: CommonLoadingIndicator(size: 16.0))
                       : null,
                 ),
 

--- a/lib/widgets/skeletons/home_feed_skeleton.dart
+++ b/lib/widgets/skeletons/home_feed_skeleton.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:romrom_fe/models/app_colors.dart';
+
+/// 홈 피드 초기 로딩 스켈레톤 — PageView 전체화면 shimmer
+class HomeFeedSkeleton extends StatelessWidget {
+  const HomeFeedSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    final height = MediaQuery.of(context).size.height;
+
+    return Skeletonizer(
+      enabled: true,
+      effect: const ShimmerEffect(baseColor: AppColors.opacity10White, highlightColor: AppColors.opacity30White),
+      child: Container(
+        width: width,
+        height: height,
+        color: AppColors.primaryBlack,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Skeleton.leaf(
+              child: Container(width: width, height: height * 0.6, color: AppColors.opacity10White),
+            ),
+            const SizedBox(height: 16),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.55, height: 18, color: AppColors.opacity10White),
+                  ),
+                  const SizedBox(height: 10),
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.35, height: 15, color: AppColors.opacity10White),
+                  ),
+                  const SizedBox(height: 10),
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.45, height: 13, color: AppColors.opacity10White),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/skeletons/item_detail_skeleton.dart
+++ b/lib/widgets/skeletons/item_detail_skeleton.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:romrom_fe/models/app_colors.dart';
+
+/// 물품 상세 초기 로딩 스켈레톤
+class ItemDetailSkeleton extends StatelessWidget {
+  const ItemDetailSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Skeletonizer(
+      enabled: true,
+      effect: ShimmerEffect(baseColor: AppColors.opacity10White, highlightColor: AppColors.opacity30White),
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Skeleton.leaf(child: SizedBox(width: 393, height: 300)),
+            SizedBox(height: 16),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  Skeleton.leaf(child: CircleAvatar(radius: 20, backgroundColor: AppColors.opacity10White)),
+                  SizedBox(width: 10),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Skeleton.leaf(child: SizedBox(width: 80, height: 13)),
+                      SizedBox(height: 6),
+                      Skeleton.leaf(child: SizedBox(width: 55, height: 11)),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(height: 20),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Skeleton.leaf(child: SizedBox(width: 264, height: 18)),
+                  SizedBox(height: 10),
+                  Skeleton.leaf(child: SizedBox(width: 157, height: 16)),
+                  SizedBox(height: 16),
+                  Skeleton.leaf(child: SizedBox(width: 311, height: 12)),
+                  SizedBox(height: 6),
+                  Skeleton.leaf(child: SizedBox(width: 264, height: 12)),
+                  SizedBox(height: 6),
+                  Skeleton.leaf(child: SizedBox(width: 187, height: 12)),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/skeletons/my_like_list_skeleton.dart
+++ b/lib/widgets/skeletons/my_like_list_skeleton.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:romrom_fe/models/app_colors.dart';
+
+/// 찜 목록 초기 로딩 스켈레톤
+class MyLikeListSkeleton extends StatelessWidget {
+  const MyLikeListSkeleton({super.key, this.itemCount = 6});
+
+  final int itemCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+
+    return ListView.separated(
+      physics: const NeverScrollableScrollPhysics(),
+      shrinkWrap: true,
+      itemCount: itemCount,
+      separatorBuilder: (_, _) => const Divider(color: AppColors.opacity10White, thickness: 1.5),
+      itemBuilder: (_, _) => Skeletonizer(
+        enabled: true,
+        effect: const ShimmerEffect(baseColor: AppColors.opacity10White, highlightColor: AppColors.opacity30White),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          child: Row(
+            children: [
+              Skeleton.leaf(
+                child: Container(
+                  width: 64,
+                  height: 64,
+                  decoration: BoxDecoration(color: AppColors.opacity10White, borderRadius: BorderRadius.circular(10)),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.45, height: 13, color: AppColors.opacity10White),
+                  ),
+                  const SizedBox(height: 6),
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.3, height: 11, color: AppColors.opacity10White),
+                  ),
+                  const SizedBox(height: 6),
+                  Skeleton.leaf(
+                    child: Container(width: width * 0.55, height: 11, color: AppColors.opacity10White),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/skeletons/notification_settings_skeleton.dart
+++ b/lib/widgets/skeletons/notification_settings_skeleton.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:romrom_fe/models/app_colors.dart';
+
+/// 알림 설정 초기 로딩 스켈레톤
+class NotificationSettingsSkeleton extends StatelessWidget {
+  const NotificationSettingsSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
+      child: Column(children: [_buildGroup(width, 4), const SizedBox(height: 16), _buildGroup(width, 1)]),
+    );
+  }
+
+  Widget _buildGroup(double width, int rowCount) {
+    return Container(
+      decoration: BoxDecoration(color: const Color(0xFF34353D), borderRadius: BorderRadius.circular(10)),
+      child: Column(children: List.generate(rowCount, (i) => _buildRow(width, i, rowCount))),
+    );
+  }
+
+  Widget _buildRow(double width, int index, int total) {
+    return Skeletonizer(
+      enabled: true,
+      effect: const ShimmerEffect(baseColor: AppColors.opacity10White, highlightColor: AppColors.opacity30White),
+      child: SizedBox(
+        height: 74,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Skeleton.leaf(
+                      child: Container(width: width * 0.35, height: 13, color: AppColors.opacity10White),
+                    ),
+                    const SizedBox(height: 8),
+                    Skeleton.leaf(
+                      child: Container(width: width * 0.55, height: 11, color: AppColors.opacity10White),
+                    ),
+                  ],
+                ),
+              ),
+              Skeleton.leaf(
+                child: Container(
+                  width: 44,
+                  height: 26,
+                  decoration: BoxDecoration(color: AppColors.opacity10White, borderRadius: BorderRadius.circular(13)),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/skeletons/trade_partner_select_skeleton.dart
+++ b/lib/widgets/skeletons/trade_partner_select_skeleton.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:romrom_fe/models/app_colors.dart';
+
+/// 거래 파트너 선택 초기 로딩 스켈레톤
+class TradePartnerSelectSkeleton extends StatelessWidget {
+  const TradePartnerSelectSkeleton({super.key, this.itemCount = 4});
+
+  final int itemCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+
+    return ListView.builder(
+      physics: const NeverScrollableScrollPhysics(),
+      shrinkWrap: true,
+      itemCount: itemCount,
+      itemBuilder: (_, _) => Skeletonizer(
+        enabled: true,
+        effect: const ShimmerEffect(baseColor: AppColors.opacity10White, highlightColor: AppColors.opacity30White),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 10),
+          child: Row(
+            children: [
+              const Skeleton.leaf(child: CircleAvatar(radius: 22, backgroundColor: AppColors.opacity10White)),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Skeleton.leaf(
+                      child: Container(width: width * 0.35, height: 13, color: AppColors.opacity10White),
+                    ),
+                    const SizedBox(height: 6),
+                    Skeleton.leaf(
+                      child: Container(width: width * 0.25, height: 11, color: AppColors.opacity10White),
+                    ),
+                  ],
+                ),
+              ),
+              Skeleton.leaf(
+                child: Container(
+                  width: 60,
+                  height: 30,
+                  decoration: BoxDecoration(color: AppColors.opacity10White, borderRadius: BorderRadius.circular(8)),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/user_profile_circular_avatar.dart
+++ b/lib/widgets/user_profile_circular_avatar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:romrom_fe/models/app_colors.dart';
 import 'package:romrom_fe/widgets/common/cached_image.dart';
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 
 const String _kDefaultProfileAsset = 'assets/images/basicProfile.svg';
 
@@ -80,7 +81,7 @@ class _UserProfileCircularAvatarState extends State<UserProfileCircularAvatar> {
       ),
       child: ClipOval(
         child: _isLoading
-            ? const Center(child: CircularProgressIndicator())
+            ? const Center(child: CommonLoadingIndicator())
             : _avatarUrl != null && _avatarUrl!.isNotEmpty && _avatarUrl != _kDefaultProfileAsset
             ? CachedImage(imageUrl: _avatarUrl!, fit: BoxFit.cover, errorWidget: _buildDefaultImage())
             : _buildDefaultImage(),


### PR DESCRIPTION
- https://github.com/TEAM-ROMROM/RomRom-FE/issues/761

## Summary

- `CommonLoadingIndicator` 공통 위젯 생성 (`CircularProgressIndicator` 래퍼, 토스 스타일)
- 전체 `CircularProgressIndicator` 직접 사용(39곳) → `CommonLoadingIndicator` 교체
- 홈피드/물품상세/찜목록/알림설정/거래파트너 화면 초기 로딩에 shimmer 스켈레톤 추가 (5개 신규 파일)
- main(v1.10.36) 기준 rebase 완료, 충돌 5개 해결

## Resolved Conflicts

| 파일 | 충돌 원인 | 해결 방법 |
|------|-----------|-----------|
| `home_tab_screen.dart` | 로딩 위젯 교체 | 761 채택 (`HomeFeedSkeleton`) |
| `my_category_settings_screen.dart` | 레이아웃 구조 + 로딩 위젯 | main 구조(Stack) 유지 + 761 위젯 |
| `notification_screen.dart` | 로딩 분기 추가 + AppFadeSlideIn | 로딩 분리 + 애니메이션 래퍼 모두 보존 |
| `register_tab_screen.dart` | import 충돌 | 두 import 모두 추가 |
| `completion_button.dart` | import 충돌 | 두 import 모두 추가 |

## Test plan

- [ ] 각 화면 초기 진입 시 스켈레톤/로딩 인디케이터 정상 표시 확인
- [ ] 로딩 완료 후 콘텐츠 정상 전환 확인
- [ ] trade_request_screen 요청 버튼 스피너 정상 동작 확인 (`_isSubmitting || _isCheckingExistence`)
- [ ] notification_screen 로딩/빈 상태/데이터 상태 전환 확인

Closes #761