### PR TITLE
로그 뷰어 복사 버튼 클릭 시 클립보드 복사 안 됨 : fix : _copyLogs async 전환 및 await Clipboard.setData 추가

### DIFF
--- a/lib/debug/server_log_client.dart
+++ b/lib/debug/server_log_client.dart
@@ -103,13 +103,26 @@ class ServerLogClient {
   }
 
   String _sseDataBuffer = '';
+  String _sseEventType = '';
 
   void _onSseLine(String line) {
-    if (line.startsWith('data:')) {
+    if (line.startsWith('event:')) {
+      // SSE 이벤트 타입 저장 (connected, heartbeat 등)
+      _sseEventType = line.substring(6).trim();
+    } else if (line.startsWith('data:')) {
       _sseDataBuffer = line.substring(5).trim();
     } else if (line.isEmpty && _sseDataBuffer.isNotEmpty) {
-      _parseAndAddLog(_sseDataBuffer);
+      final eventType = _sseEventType;
+      final data = _sseDataBuffer;
+      _sseEventType = '';
       _sseDataBuffer = '';
+
+      if (eventType == 'connected' || data == 'connected') {
+        // BE 연결 수립 확인 이벤트 — 시스템 로그로만 표시, JSON 파싱 불필요
+        _addSystemLog('[서버 로그] 서버 연결 확인됨');
+        return;
+      }
+      _parseAndAddLog(data);
     }
   }
 
@@ -188,5 +201,6 @@ class ServerLogClient {
     _httpClient = null;
     _isConnected = false;
     _sseDataBuffer = '';
+    _sseEventType = '';
   }
 }

--- a/lib/debug/widgets/debug_log_panel.dart
+++ b/lib/debug/widgets/debug_log_panel.dart
@@ -93,7 +93,7 @@ class _DebugLogPanelState extends State<DebugLogPanel> {
     _applyFilters();
   }
 
-  void _copyLogs() {
+  Future<void> _copyLogs() async {
     final text = _filteredLogs
         .map((log) {
           final time =
@@ -103,11 +103,17 @@ class _DebugLogPanelState extends State<DebugLogPanel> {
           return '$time ${log.message}';
         })
         .join('\n');
-    Clipboard.setData(ClipboardData(text: text));
-    setState(() => _showCopiedFeedback = true);
-    Future.delayed(const Duration(seconds: 1), () {
-      if (mounted) setState(() => _showCopiedFeedback = false);
-    });
+    try {
+      // 클립보드 쓰기 완료 후 피드백 표시 (await 없으면 복사 전에 UI 업데이트됨)
+      await Clipboard.setData(ClipboardData(text: text));
+      if (!mounted) return;
+      setState(() => _showCopiedFeedback = true);
+      Future.delayed(const Duration(seconds: 1), () {
+        if (mounted) setState(() => _showCopiedFeedback = false);
+      });
+    } catch (_) {
+      // 복사 실패 시 피드백 없이 조용히 종료
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
- `_copyLogs()`에서 `Clipboard.setData()` 호출 시 `await` 누락으로 복사 완료 전 UI 피드백이 표시되는 버그 수정
- `void` → `Future<void> async`로 전환, `try/catch` 에러 핸들링 추가
- 복사 성공 후에만 "복사됨!" 피드백 표시되도록 순서 보장
- SSE `event:` 타입 라인 파싱 추가 — `connected` 이벤트를 JSON 파싱 없이 시스템 로그로만 표시
- `_sseEventType` 상태 추가, `disconnect()` 시 초기화 처리

## Test plan
- [ ] 로그 뷰어 복사 버튼 클릭 시 클립보드에 실제로 복사되는지 확인 (iOS)
- [ ] 복사 후 "복사됨!" 피드백이 1초간 표시되는지 확인
- [ ] 서버 로그 패널 열었을 때 SSE 연결이 안정적으로 유지되는지 확인
- [ ] `connected` 이벤트 수신 시 "서버 연결 확인됨" 시스템 로그 표시 확인
- [ ] 실제 API 호출 시 서버 로그가 패널에 표시되는지 확인

Closes #792
Closes #796