### PR TITLE
❗[버그][홈] 광고 슬롯 노출 타이밍 및 카드 펼침 애니메이션 재실행

### DIFF
--- a/docs/superpowers/plans/2026-05-08-홈-광고-슬롯-노출-타이밍-및-카드-펼침-애니메이션-재실행.md
+++ b/docs/superpowers/plans/2026-05-08-홈-광고-슬롯-노출-타이밍-및-카드-펼침-애니메이션-재실행.md
@@ -1,0 +1,334 @@
+# 홈 광고 슬롯 노출 타이밍 및 카드 펼침 애니메이션 재실행 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 홈 피드 광고 슬롯 진입 시 발생하는 두 가지 UX 버그를 수정한다 — (1) 광고 로딩 placeholder가 다른 피드 슬롯과 시각적으로 다르게 노출되어 광고 정체가 미리 드러나는 문제, (2) PageView 페이지 전환 시 `HomeTabCardHand`의 fan-out 초기화 애니메이션이 재실행되는 문제.
+
+**Architecture:**
+- 광고 placeholder를 `HomeFeedSkeleton`으로 통일해 일반 피드 슬롯과 동일한 shimmer UI를 노출한다.
+- `HomeTabCardHand`에 `ValueKey`를 부여해 Stack children 인덱스 시프트가 일어나도 Flutter element matching이 성공하게 만들어 State 보존 → fan-out 애니메이션 재실행을 차단한다.
+- 변경 파일은 2개, 변경량은 최소(라인 단위). 기존 인터랙션/구조는 유지한다.
+
+**Tech Stack:** Flutter, `google_mobile_ads`, `skeletonizer`, `flutter_screenutil`
+
+**Spec:** `docs/superpowers/specs/2026-05-08-홈-광고-슬롯-노출-타이밍-및-카드-펼침-애니메이션-재실행-design.md`
+
+**Issue:** [#839](https://github.com/TEAM-ROMROM/RomRom-FE/issues/839)
+
+---
+
+## File Structure
+
+| 파일 | 변경 종류 | 책임 |
+|------|----------|------|
+| `lib/widgets/native_ad_widget.dart` | 수정 | 광고 로드 전 placeholder를 `HomeFeedSkeleton`으로 교체. 로드 실패 시에도 동일 처리. |
+| `lib/screens/home_tab_screen.dart` | 수정 | `HomeTabCardHand` 호출에 `key: const ValueKey('home_card_hand')` 추가. |
+
+신규 파일 없음. 기존 위젯/스크린의 좁은 범위 수정만 발생.
+
+---
+
+## 환경 제약 (중요)
+
+- 내부망 환경: `flutter pub get`, `flutter analyze`, `flutter test`, `flutter build` 등 외부 인터넷 필요 명령 실행 **불가**.
+- 사용 가능한 명령: `dart format --line-length=120 .` (포매팅만)
+- 린트/빌드/테스트는 사용자가 별도 환경에서 직접 수행한다 → 본 plan에서는 검증을 dart format + 코드 정합성 육안 확인 + 수동 테스트로 한정한다.
+- `flutter test` 실행 단계가 등장하면 **사용자가 외부 환경에서 실행할 항목**으로 명시한다.
+
+---
+
+## Task 1: 광고 슬롯 placeholder를 `HomeFeedSkeleton`으로 교체
+
+**Files:**
+- Modify: `lib/widgets/native_ad_widget.dart`
+
+광고 로드 전(또는 로드 실패 후) 검정 배경 + `CommonLoadingIndicator` 조합을 `HomeFeedSkeleton`으로 교체해 일반 피드 슬롯과 시각적으로 통일한다. 로드 실패 시에도 스켈레톤을 유지해 사용자가 광고 슬롯 정체를 미리 인지하지 않게 한다.
+
+- [ ] **Step 1: 변경 전 파일 내용 확인**
+
+Read 도구로 `lib/widgets/native_ad_widget.dart` 전체를 확인. 다음 두 부분이 존재해야 한다:
+- import 5번째 줄 부근: `import 'package:romrom_fe/widgets/common/loading_indicator.dart';`
+- `build` 메서드 분기:
+
+```dart
+if (!_isLoaded || _nativeAd == null) {
+  return const ColoredBox(
+    color: AppColors.primaryBlack,
+    child: Center(child: CommonLoadingIndicator()),
+  );
+}
+```
+
+만약 코드가 이미 다른 형태라면 plan을 중단하고 사용자에게 알린다 (스펙과 실제 코드 불일치).
+
+- [ ] **Step 2: import 교체**
+
+Edit 도구로 다음 변경:
+
+```dart
+import 'package:romrom_fe/widgets/common/loading_indicator.dart';
+```
+
+→
+
+```dart
+import 'package:romrom_fe/widgets/skeletons/home_feed_skeleton.dart';
+```
+
+- [ ] **Step 3: build 메서드 placeholder 분기 교체**
+
+Edit 도구로 다음 변경:
+
+```dart
+if (!_isLoaded || _nativeAd == null) {
+  // 광고 로드 전 로딩 스피너 표시
+  return const ColoredBox(
+    color: AppColors.primaryBlack,
+    child: Center(child: CommonLoadingIndicator()),
+  );
+}
+```
+
+→
+
+```dart
+if (!_isLoaded || _nativeAd == null) {
+  // 광고 로드 전(또는 로드 실패) — 일반 피드 슬롯과 동일한 스켈레톤 노출
+  return const HomeFeedSkeleton();
+}
+```
+
+`AppColors` import는 아래 `ColoredBox(color: AppColors.primaryBlack, ...)`에서 여전히 사용하므로 **유지**.
+
+- [ ] **Step 4: 변경 결과 검증 (Grep)**
+
+Grep으로 다음 확인:
+
+```bash
+# CommonLoadingIndicator 잔존 여부 (있으면 안 됨)
+Grep pattern="CommonLoadingIndicator" path="lib/widgets/native_ad_widget.dart"
+# loading_indicator.dart import 잔존 여부 (있으면 안 됨)
+Grep pattern="loading_indicator.dart" path="lib/widgets/native_ad_widget.dart"
+# HomeFeedSkeleton 사용 여부 (1회 이상)
+Grep pattern="HomeFeedSkeleton" path="lib/widgets/native_ad_widget.dart"
+```
+
+기대 결과:
+- `CommonLoadingIndicator`: 매칭 0개
+- `loading_indicator.dart`: 매칭 0개
+- `HomeFeedSkeleton`: import 1회 + 사용 1회 = 매칭 2개
+
+- [ ] **Step 5: dart format 실행**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/widgets/native_ad_widget.dart
+```
+
+기대: `Formatted` 또는 `Unchanged` 출력.
+
+- [ ] **Step 6: 커밋 보류**
+
+**커밋하지 말 것.** CLAUDE.md 규칙: 사용자 명시적 허락 없이 git add/commit 금지. Task 2 완료 후 사용자가 일괄 커밋 요청 시까지 변경 사항을 staging 안 한다.
+
+---
+
+## Task 2: `HomeTabCardHand`에 `ValueKey` 부여
+
+**Files:**
+- Modify: `lib/screens/home_tab_screen.dart`
+
+Stack children 인덱스 시프트(광고 슬롯 진입 시 알림아이콘 Positioned 제거로 발생) 상황에서도 Flutter element matching이 성공하도록 `HomeTabCardHand`에 안정적인 키를 부여해 State 보존을 보장한다.
+
+- [ ] **Step 1: 변경 전 파일 내용 확인**
+
+Read 도구로 `lib/screens/home_tab_screen.dart`의 line 678~689 부근을 확인. 다음과 정확히 일치해야 한다:
+
+```dart
+if (!_isBlurShown)
+  Positioned(
+    left: 0,
+    right: 0,
+    bottom: -130.h,
+    child: HomeTabCardHand(
+      cards: _myCards,
+      onCardDrop: _handleCardDrop,
+      highlightedItemIds: _aiHighlightedItemIds,
+      dragEnabled: !_isAdAtVirtualIndex(_currentVirtualIndex),
+    ),
+  )
+```
+
+만약 라인 번호가 약간 다르거나 prop 순서가 다르면 실제 코드를 따른다. 단, 위 형태와 다른 새로운 prop이 추가됐다면 사용자에게 확인 요청.
+
+- [ ] **Step 2: ValueKey 추가**
+
+Edit 도구로 다음 변경 (`old_string`은 충분히 unique한 컨텍스트 포함):
+
+```dart
+    child: HomeTabCardHand(
+      cards: _myCards,
+      onCardDrop: _handleCardDrop,
+      highlightedItemIds: _aiHighlightedItemIds,
+      dragEnabled: !_isAdAtVirtualIndex(_currentVirtualIndex),
+    ),
+```
+
+→
+
+```dart
+    child: HomeTabCardHand(
+      key: const ValueKey('home_card_hand'),
+      cards: _myCards,
+      onCardDrop: _handleCardDrop,
+      highlightedItemIds: _aiHighlightedItemIds,
+      dragEnabled: !_isAdAtVirtualIndex(_currentVirtualIndex),
+    ),
+```
+
+- [ ] **Step 3: 키 충돌 재검증**
+
+Grep으로 `lib/` 전체에서 `'home_card_hand'` 사용처가 단 한 곳(이번 추가)인지 확인:
+
+```bash
+Grep pattern="home_card_hand" path="lib/" output_mode="content"
+```
+
+기대: `lib/screens/home_tab_screen.dart` 1개 라인만 매칭.
+
+- [ ] **Step 4: ValueKey 추가 위치 검증**
+
+Grep으로 `HomeTabCardHand(` 호출 위치들을 확인:
+
+```bash
+Grep pattern="HomeTabCardHand\(" path="lib/" output_mode="content" -n=true
+```
+
+기대: `lib/screens/home_tab_screen.dart`의 호출에서 바로 다음 라인이 `key: const ValueKey('home_card_hand'),`로 시작.
+
+- [ ] **Step 5: dart format 실행**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/screens/home_tab_screen.dart
+```
+
+기대: `Formatted` 또는 `Unchanged` 출력.
+
+- [ ] **Step 6: 커밋 보류**
+
+**커밋하지 말 것.** Task 3 정합성 검토 후 사용자가 일괄 커밋 요청할 때까지 staging 안 함.
+
+---
+
+## Task 3: 변경 정합성 종합 검토 (포매팅 + 정적 검증)
+
+**Files:**
+- Read-only: `lib/widgets/native_ad_widget.dart`, `lib/screens/home_tab_screen.dart`
+
+내부망에서 `flutter analyze` 실행 불가하므로 코드 정합성 정적 검증만 수행한다. 수동 테스트는 사용자가 별도 환경에서 진행.
+
+- [ ] **Step 1: 두 파일 git diff 출력**
+
+```bash
+git -C "D:/0-suh/project/RomRom-FE-Worktree/20260508_#839_버그_홈_광고_슬롯_노출_타이밍_및_카드_펼침_애니메이션_재실행" diff -- lib/widgets/native_ad_widget.dart lib/screens/home_tab_screen.dart
+```
+
+기대 변경 라인 합계: 약 5~7줄 추가/삭제. 그 이상이면 의도 외 변경 의심 → 검토.
+
+- [ ] **Step 2: import 정렬 확인**
+
+`lib/widgets/native_ad_widget.dart`의 상단 import 블록을 Read로 확인. 다음 import가 모두 존재해야 한다:
+- `package:flutter/material.dart`
+- `package:google_mobile_ads/google_mobile_ads.dart`
+- `package:romrom_fe/models/app_colors.dart`
+- `package:romrom_fe/services/ad_mob_service.dart`
+- `package:romrom_fe/widgets/skeletons/home_feed_skeleton.dart` (신규)
+
+`loading_indicator.dart` import가 없어야 한다.
+
+- [ ] **Step 3: HomeFeedSkeleton 의존성 검증**
+
+`lib/widgets/skeletons/home_feed_skeleton.dart` 파일이 존재하고 `HomeFeedSkeleton` 클래스를 export하는지 Read로 확인.
+기대: `class HomeFeedSkeleton extends StatelessWidget` 발견.
+
+- [ ] **Step 4: 사용하지 않는 import 잔존 검사**
+
+`native_ad_widget.dart` 안에서 import된 심볼이 모두 실제 사용되는지 확인:
+- `material.dart` → `StatefulWidget`, `BuildContext` 등 사용
+- `google_mobile_ads.dart` → `NativeAd`, `NativeAdListener`, `AdRequest`, `AdWidget` 등 사용
+- `app_colors.dart` → `AppColors.primaryBlack` 사용 (여전히 `AdWidget` 감싸는 `ColoredBox`에 존재)
+- `ad_mob_service.dart` → `AdMobService.nativeAdUnitId` 사용
+- `home_feed_skeleton.dart` → `HomeFeedSkeleton()` 사용
+
+기대: 모두 매칭.
+
+- [ ] **Step 5: dart format 전체 재실행**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 lib/widgets/native_ad_widget.dart lib/screens/home_tab_screen.dart
+```
+
+기대: `Unchanged` 또는 `Formatted` 출력. 추가 포맷 변경이 발생하면 그것도 git diff에 포함.
+
+- [ ] **Step 6: 사용자 수동 테스트 가이드 출력**
+
+작업 완료 보고 시 다음 테스트 가이드를 사용자에게 제시한다:
+
+```
+실기기 테스트 (iOS / Android):
+
+1. 홈 탭 진입 → 첫 fan-out 애니메이션 완료 대기
+2. 피드 아래로 스와이프 → 4번째 슬롯(광고)
+   - 기대 ①: 일반 피드와 동일한 shimmer 스켈레톤 노출 (검정 dimmer + 스피너 아님)
+   - 기대 ②: 카드덱이 펼쳐진 상태 그대로 유지 (중앙 모임/펼침 재생 안 됨)
+3. 광고 로드 완료 대기 → 스켈레톤 → 실제 광고 자연 전환
+4. 광고 슬롯 ↔ 일반 슬롯 왕복 → 카드덱 fan-out 재실행 안 됨
+5. 광고 슬롯에서 카드덱 카드 위로 드래그 → 드래그 차단 (기존 동작 유지)
+
+flutter analyze / flutter test는 외부 환경에서 실행해주세요.
+```
+
+- [ ] **Step 7: 사용자 커밋 승인 대기**
+
+**커밋하지 말 것.** 작업 완료 보고 후 사용자가 명시적으로 "커밋해줘"라고 요청하면 그때 `/cassiiopeia:commit` 스킬을 통해 커밋한다. CLAUDE.md 절대 규칙: 자동 커밋 금지.
+
+---
+
+## 작업 완료 후 후속 작업 (사용자 승인 시)
+
+| 단계 | 스킬 | 동작 |
+|------|------|------|
+| Commit | `/cassiiopeia:commit` | 변경 파일 일괄 커밋 (메시지 컨벤션 사용자 제공 시) |
+| PR 생성 | `/cassiiopeia:github` | GitHub PR 생성 + 이슈 연결 |
+| 빌드 트리거 | `/cassiiopeia:github` | 이슈에 `@suh-lab app build` 댓글 추가 |
+| 테스트케이스 작성 | `/cassiiopeia:testcase` | QA용 테스트케이스 MD 작성 |
+
+---
+
+## Self-Review 결과
+
+**1. Spec coverage**
+
+| Spec 섹션 | 대응 Task |
+|-----------|----------|
+| 4.2 `native_ad_widget.dart` 변경 | Task 1 전체 |
+| 4.3 `home_tab_screen.dart` 변경 | Task 2 전체 |
+| 4.2 import 변경 | Task 1 Step 2, Task 3 Step 2/4 |
+| 6 키 충돌 검증 | Task 2 Step 3 |
+| 7 수동 테스트 케이스 1~5 | Task 3 Step 6 |
+
+누락 없음. ✅
+
+**2. Placeholder scan**
+
+- "TBD/TODO/implement later" 사용 없음 ✅
+- "appropriate error handling" 같은 모호 표현 없음 ✅
+- 모든 코드 변경 단계에 실제 before/after 코드 명시 ✅
+- 명령어는 실제 실행 가능한 형태 ✅
+
+**3. Type consistency**
+
+- `HomeFeedSkeleton` 클래스명 모든 등장 위치에서 일치 ✅
+- `ValueKey('home_card_hand')` 키 값 모든 등장 위치에서 일치 ✅
+- import 경로 절대경로 형식으로 통일 ✅
+
+자체검토 통과. 이슈 없음.

--- a/docs/superpowers/specs/2026-05-08-홈-광고-슬롯-노출-타이밍-및-카드-펼침-애니메이션-재실행-design.md
+++ b/docs/superpowers/specs/2026-05-08-홈-광고-슬롯-노출-타이밍-및-카드-펼침-애니메이션-재실행-design.md
@@ -1,0 +1,252 @@
+# 홈 광고 슬롯 노출 타이밍 및 카드 펼침 애니메이션 재실행 — 설계 문서
+
+- **Issue**: [#839](https://github.com/TEAM-ROMROM/RomRom-FE/issues/839)
+- **작성일**: 2026-05-08
+- **Branch**: `20260508_#839_버그_홈_광고_슬롯_노출_타이밍_및_카드_펼침_애니메이션_재실행`
+
+---
+
+## 1. 배경
+
+홈 피드에는 일반 아이템 슬롯과 광고 슬롯(`NativeAdWidget`)이 섞여 있고, 하단에는 사용자의 내 물품을 보여주는 카드덱(`HomeTabCardHand`)이 고정 노출된다. 사용자가 피드를 스크롤하면 다음 두 가지 UX 문제가 발생한다.
+
+### 문제 1 — 광고 슬롯 로딩 UI가 다른 피드 슬롯과 달라 광고 정체가 미리 노출됨
+
+- 일반 피드 슬롯은 로딩 중 `HomeFeedSkeleton` (shimmer 스켈레톤)으로 표시된다.
+- 광고 슬롯은 `NativeAdWidget`이 광고 로드 전까지 `AppColors.primaryBlack` 배경 위 `CommonLoadingIndicator` (dimmer 스피너)를 표시한다.
+- 결과: 사용자가 광고 로드 전부터 "이 슬롯은 광고다"라는 사실을 시각적으로 인지 → 광고에 대한 거부감 유발 + 광고 회피 행동 가능성.
+
+### 문제 2 — 광고 슬롯 페이지 전환 시 카드덱 fan-out 초기화 애니메이션이 재실행됨
+
+- `HomeTabCardHand`는 `initState` → `_initializeAnimations()` → `Future.delayed(500ms)` → `_fanController.forward()` (1000ms `Curves.easeOutExpo`)로 카드들이 화면 중앙 하단에 모였다가 부채꼴로 펼쳐지는 fan-out 애니메이션을 재생한다.
+- 이 애니메이션은 카드덱 **초기화 시점에만** 재생되어야 한다.
+- 그러나 광고 슬롯으로 PageView 페이지 전환이 일어날 때마다 카드덱 fan-out이 다시 재생됨.
+
+---
+
+## 2. 원인 진단
+
+### 문제 1 원인
+
+`lib/widgets/native_ad_widget.dart` line 67~73:
+
+```dart
+if (!_isLoaded || _nativeAd == null) {
+  return const ColoredBox(
+    color: AppColors.primaryBlack,
+    child: Center(child: CommonLoadingIndicator()),
+  );
+}
+```
+
+광고 로드 전 placeholder가 `HomeFeedSkeleton`이 아닌 dimmer + 스피너 조합. 일반 피드 placeholder와 시각적 통일성 없음.
+
+### 문제 2 원인
+
+`lib/screens/home_tab_screen.dart` line 565~736의 `Stack` children 구성이 조건부:
+
+```
+Stack children:
+  [0] PageView                                              (항상)
+  [1] 알림아이콘 Positioned                                  (조건부: !_isBlurShown && !_isAdAtVirtualIndex(...))
+  [2] HomeTabCardHand Positioned                            (조건부: !_isBlurShown)
+       또는 등록하기 버튼 Positioned                          (조건부: _isBlurShown && !_isAdAtVirtualIndex(...))
+```
+
+광고 슬롯 진입 시:
+1. `_currentVirtualIndex`가 광고 인덱스로 갱신 → `_isAdAtVirtualIndex(_currentVirtualIndex) == true`
+2. 알림아이콘 Positioned 조건 false → Stack children 리스트에서 **제거**됨
+3. `HomeTabCardHand`가 Stack children 인덱스 2 → 1로 시프트
+4. Flutter element matching: children 리스트 위치가 바뀌면 동일 위젯 type이라도 별도 element로 간주 → **State 파괴 후 재생성**
+5. `_HomeTabCardHandState.initState` 재호출 → `_initializeAnimations()` → fan-out 애니메이션 재실행
+
+이 동작은 #789 후속 작업 commit `c13519c`/`5752e07`/`aa8fc50`에서 카드덱을 광고 슬롯에서도 표시되도록 변경하면서 노출되었으나, 알림아이콘 조건부 분기는 그대로 유지되어 시프트가 계속 발생.
+
+---
+
+## 3. 설계 목표
+
+1. 광고 슬롯 로딩 UI를 일반 피드 슬롯과 시각적으로 동일하게 만들어, 사용자가 광고 정체를 미리 인지하지 못하게 한다.
+2. PageView 페이지 전환 (특히 광고 슬롯 진입/이탈) 시 `HomeTabCardHand`의 State가 보존되어 fan-out 애니메이션이 재실행되지 않게 한다.
+3. 카드덱 인스턴스는 홈 탭 라이프사이클 동안 단 한 번만 생성/초기화된다 (`_isBlurShown` 분기 변동 제외).
+4. 기존 인터랙션 (카드덱 드래그, AdMob 로드, AI 하이라이트, 코치마크) 동작 유지.
+
+---
+
+## 4. 설계
+
+### 4.1 변경 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `lib/widgets/native_ad_widget.dart` | 광고 로드 전 placeholder를 `HomeFeedSkeleton`으로 교체 |
+| `lib/screens/home_tab_screen.dart` | `HomeTabCardHand` 호출에 `key: const ValueKey('home_card_hand')` 추가 |
+
+### 4.2 `lib/widgets/native_ad_widget.dart`
+
+**기존**:
+
+```dart
+@override
+Widget build(BuildContext context) {
+  if (!_isLoaded || _nativeAd == null) {
+    return const ColoredBox(
+      color: AppColors.primaryBlack,
+      child: Center(child: CommonLoadingIndicator()),
+    );
+  }
+  return Center(
+    child: ColoredBox(
+      color: AppColors.primaryBlack,
+      child: AdWidget(ad: _nativeAd!),
+    ),
+  );
+}
+```
+
+**변경**:
+
+```dart
+@override
+Widget build(BuildContext context) {
+  if (!_isLoaded || _nativeAd == null) {
+    return const HomeFeedSkeleton();
+  }
+  return Center(
+    child: ColoredBox(
+      color: AppColors.primaryBlack,
+      child: AdWidget(ad: _nativeAd!),
+    ),
+  );
+}
+```
+
+**import 변경**:
+- 추가: `import 'package:romrom_fe/widgets/skeletons/home_feed_skeleton.dart';`
+- 제거: `import 'package:romrom_fe/widgets/common/loading_indicator.dart';` (이 파일 내 다른 사용처 없음 검증 완료)
+- `app_colors.dart` import는 `AdWidget` 감싸는 `ColoredBox`에서 여전히 사용 → 유지
+
+**광고 로드 실패 시 동작**:
+- `onAdFailedToLoad` → `_nativeAd?.dispose()` → `setState(() => _nativeAd = null)` (기존 그대로)
+- `_isLoaded == false || _nativeAd == null` 분기 → `HomeFeedSkeleton` 계속 표시
+- 사용자는 광고 슬롯 존재를 인지하지 않고 다음 슬롯으로 자연스럽게 스크롤 가능
+
+### 4.3 `lib/screens/home_tab_screen.dart`
+
+**기존** (line 678~689):
+
+```dart
+if (!_isBlurShown)
+  Positioned(
+    left: 0,
+    right: 0,
+    bottom: -130.h,
+    child: HomeTabCardHand(
+      cards: _myCards,
+      onCardDrop: _handleCardDrop,
+      highlightedItemIds: _aiHighlightedItemIds,
+      dragEnabled: !_isAdAtVirtualIndex(_currentVirtualIndex),
+    ),
+  )
+```
+
+**변경**:
+
+```dart
+if (!_isBlurShown)
+  Positioned(
+    left: 0,
+    right: 0,
+    bottom: -130.h,
+    child: HomeTabCardHand(
+      key: const ValueKey('home_card_hand'),
+      cards: _myCards,
+      onCardDrop: _handleCardDrop,
+      highlightedItemIds: _aiHighlightedItemIds,
+      dragEnabled: !_isAdAtVirtualIndex(_currentVirtualIndex),
+    ),
+  )
+```
+
+**작동 원리**:
+- `ValueKey('home_card_hand')`는 트리 내 동일 element 식별자 역할
+- Stack children 인덱스가 시프트해도 Flutter는 같은 키를 가진 위젯을 동일 element로 매칭
+- 결과: `_HomeTabCardHandState` 보존 → `initState` 재호출 안 됨 → fan-out 애니메이션 재실행 차단
+
+**키 충돌 검증**:
+- `lib/` 전체에서 `home_card_hand` 문자열 사용 확인 결과: 충돌 없음
+
+---
+
+## 5. 데이터 흐름
+
+### 시나리오 1: 광고 슬롯 진입 (광고 로드 중)
+
+1. PageView 광고 인덱스로 전환 → `onPageChanged` → `setState` → 부모 rebuild
+2. `NativeAdWidget` 새로 생성 → `_loadAd()` → `_isLoaded = false`
+3. `build`: `HomeFeedSkeleton` 반환 (일반 피드 슬롯과 동일 UI)
+4. Stack children: 알림아이콘 분기 false → 리스트에서 제거됨
+5. `HomeTabCardHand`에 `ValueKey` 부여 → Flutter element matching 성공 → State 보존
+6. fan-out 애니메이션 재실행되지 않음
+
+### 시나리오 2: 광고 로드 완료
+
+1. `onAdLoaded` → `setState(() => _isLoaded = true)`
+2. `build`: `AdWidget` 반환 → 실제 광고 표시
+3. 카드덱 영향 없음
+
+### 시나리오 3: 광고 로드 실패
+
+1. `onAdFailedToLoad` → `_nativeAd?.dispose()` → `setState(() => _nativeAd = null)`
+2. `build`: `_isLoaded == false || _nativeAd == null` → `HomeFeedSkeleton` 계속 표시
+3. 사용자가 다음 페이지로 스크롤 → 광고 슬롯 dispose
+
+### 시나리오 4: 광고 슬롯 → 일반 피드 슬롯 복귀
+
+1. PageView 다음 인덱스로 전환 → 알림아이콘 다시 Stack에 추가
+2. `HomeTabCardHand` `ValueKey` 동일 → State 그대로 유지
+3. fan-out 재실행되지 않음
+
+---
+
+## 6. 에러 처리 / 엣지 케이스
+
+| 케이스 | 처리 |
+|--------|------|
+| 광고 로드 실패 | 스켈레톤 유지. 추가 처리 불필요. |
+| 광고 슬롯 재진입 (위→아래→위) | PageView 캐싱 정책에 따름. 새 인스턴스 생성 + 새 광고 요청. 카드덱은 `ValueKey`로 보존. |
+| `_isBlurShown == true` (내 물건 0개) | `HomeTabCardHand` 자체가 렌더링 안 됨. 광고 슬롯 진입도 차단됨 (`physics: NeverScrollableScrollPhysics`). 영향 없음. |
+| `widget.cards` prop 변경 (`_loadMyCards` 후) | `ValueKey` 동일 → State 보존 → `didUpdateWidget` 호출. 단, 현재 `didUpdateWidget`에서 `widget.cards` 비교 안 함 (line 198~234) → 카드 변경이 카드덱 리스트에 반영 안 되는 별개 버그 존재. 본 이슈 범위 외. |
+| `ValueKey` 충돌 | `lib/` 전체에 `home_card_hand` 사용처 없음 확인. 충돌 없음. |
+
+---
+
+## 7. 테스트 계획 (수동)
+
+**환경**: 실기기 (iOS / Android)
+
+| # | 케이스 | 기대 동작 |
+|---|--------|----------|
+| 1 | 홈 탭 진입 → 광고 슬롯까지 스와이프 (광고 로드 중) | 일반 피드와 동일한 shimmer 스켈레톤 노출. dimmer + 스피너 아님. |
+| 2 | 첫 fan-out 완료 대기 → 광고 슬롯 진입 | 카드덱이 펼쳐진 상태 유지. 중앙 모임/펼침 애니메이션 재실행 안 됨. |
+| 3 | 광고 슬롯에서 광고 로드 완료 대기 | 스켈레톤 → 실제 광고 자연 전환. |
+| 4 | 광고 슬롯 ↔ 일반 슬롯 왕복 | 카드덱 fan-out 재실행 안 됨. 위치/상태 보존. |
+| 5 | 광고 슬롯에서 카드덱 카드 위로 드래그 시도 | 드래그 안 됨 (`dragEnabled: false`). 기존 동작 유지. |
+
+---
+
+## 8. 범위 외
+
+- `HomeTabCardHand.didUpdateWidget`에서 `widget.cards` 비교 누락으로 인한 카드 리스트 갱신 미반영 (별개 이슈로 분리 권장)
+- `widget test` 추가 (이번 작업은 수동 테스트로 한정)
+- 광고 노출 빈도/슬롯 패턴 (`_adFreeCount`, `_adInterval`) 변경
+- AdMob 광고 로드 정책 (재시도, timeout 등) 변경
+
+---
+
+## 9. 결과 기준 (DoD)
+
+- [ ] 광고 슬롯 로딩 placeholder가 `HomeFeedSkeleton`으로 표시된다
+- [ ] 광고 슬롯 진입/이탈 시 `HomeTabCardHand` State가 보존되어 fan-out 애니메이션이 재실행되지 않는다
+- [ ] 기존 카드덱 드래그, AI 하이라이트, AdMob 로드 동작이 정상 유지된다
+- [ ] 위 테스트 케이스 1~5 모두 기대 동작과 일치한다

--- a/lib/screens/home_tab_screen.dart
+++ b/lib/screens/home_tab_screen.dart
@@ -681,6 +681,7 @@ class _HomeTabScreenState extends State<HomeTabScreen> {
             right: 0,
             bottom: -130.h,
             child: HomeTabCardHand(
+              key: const ValueKey('home_card_hand'),
               cards: _myCards,
               onCardDrop: _handleCardDrop,
               highlightedItemIds: _aiHighlightedItemIds,

--- a/lib/widgets/native_ad_widget.dart
+++ b/lib/widgets/native_ad_widget.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:romrom_fe/models/app_colors.dart';
 import 'package:romrom_fe/services/ad_mob_service.dart';
-import 'package:romrom_fe/widgets/common/loading_indicator.dart';
+import 'package:romrom_fe/widgets/skeletons/home_feed_skeleton.dart';
 
 /// 홈 피드용 네이티브 광고 위젯
 /// PageView 한 페이지를 채우는 전체화면 크기로 표시됨
@@ -65,11 +65,8 @@ class _NativeAdWidgetState extends State<NativeAdWidget> {
   @override
   Widget build(BuildContext context) {
     if (!_isLoaded || _nativeAd == null) {
-      // 광고 로드 전 로딩 스피너 표시
-      return const ColoredBox(
-        color: AppColors.primaryBlack,
-        child: Center(child: CommonLoadingIndicator()),
-      );
+      // 광고 로드 전(또는 로드 실패) — 일반 피드 슬롯과 동일한 스켈레톤 노출
+      return const HomeFeedSkeleton();
     }
 
     return Center(


### PR DESCRIPTION
## Summary

이슈 [#839](https://github.com/TEAM-ROMROM/RomRom-FE/issues/839) — 홈 피드 광고 슬롯 진입 시 발생하는 두 가지 UX 버그를 수정합니다.

### 변경 내용

- **광고 슬롯 placeholder 통일** — `NativeAdWidget`이 광고 로드 전(또는 로드 실패) 표시하던 `검정 dimmer + CommonLoadingIndicator` 조합을 일반 피드 슬롯과 동일한 `HomeFeedSkeleton` shimmer UI로 교체했습니다. 이로 인해 사용자가 광고 정체를 미리 인지하지 못하게 됩니다.
- **카드덱 fan-out 재실행 차단** — `HomeTabCardHand` 호출에 `key: const ValueKey('home_card_hand')`를 부여해, 광고 슬롯 진입 시 알림아이콘 `Positioned`가 Stack children에서 제거되며 발생하던 인덱스 시프트 → element matching 실패 → State 파괴 → fan-out 애니메이션 재실행 체인을 차단했습니다.

### 변경 파일

| 파일 | +/- |
|------|-----|
| `lib/widgets/native_ad_widget.dart` | +3 / -6 |
| `lib/screens/home_tab_screen.dart` | +1 / -0 |
| `docs/superpowers/specs/2026-05-08-홈-광고-슬롯-노출-타이밍-및-카드-펼침-애니메이션-재실행-design.md` | 신규 |
| `docs/superpowers/plans/2026-05-08-홈-광고-슬롯-노출-타이밍-및-카드-펼침-애니메이션-재실행.md` | 신규 |

## Test plan

- [ ] 홈 탭 진입 → 첫 fan-out 애니메이션 재생 후 완료 대기
- [ ] 피드 아래로 스와이프 → 광고 슬롯(4번째)에서 일반 피드와 동일한 shimmer 스켈레톤 노출 (검정 dimmer + 스피너 아님)
- [ ] 광고 슬롯 진입 시 카드덱이 펼쳐진 상태 그대로 유지 (중앙 모임/펼침 재생 안 됨)
- [ ] 광고 로드 완료 → 스켈레톤 → 실제 광고 자연 전환
- [ ] 광고 슬롯 ↔ 일반 슬롯 왕복 → 카드덱 fan-out 재실행 안 됨
- [ ] 광고 슬롯에서 카드덱 카드 위로 드래그 → 드래그 차단 (기존 동작 유지)
- [ ] iOS / Android 양쪽 실기기 확인

## Related

Closes #839


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 홈 피드 광고 슬롯의 로딩 UI를 일관된 스켈레톤 스타일로 개선하여 시각적 일관성 강화
  * 홈 탭에서 페이지 전환 시 카드 펼침 애니메이션이 반복되는 문제 해결

* **Documentation**
  * 광고 슬롯 UI 개선 및 카드 애니메이션 안정화 관련 구현 계획 및 설계 문서 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->