### PR TITLE
⚙️[기능추가][에러처리] 에러 메시지 표시 방식 ErrorUtils로 통일

### DIFF
--- a/lib/screens/chat_room_screen.dart
+++ b/lib/screens/chat_room_screen.dart
@@ -576,12 +576,12 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> with WidgetsBindingObse
             _messages.removeWhere((m) => m.chatMessageId == localId);
             _uploadingLocalIds.remove(localId);
           });
-          CommonSnackBar.show(context: context, message: '이미지 전송에 실패했습니다: $e', type: SnackBarType.error);
+          CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
         }
       }
     } catch (e) {
       if (context.mounted) {
-        CommonSnackBar.show(context: context, message: '이미지 선택에 실패했습니다: $e', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     } finally {
       if (mounted) _isPickingImage = false;
@@ -654,7 +654,7 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> with WidgetsBindingObse
       await ChatApi().cancelTradeCompletionRequest(chatRoomId: widget.chatRoomId);
     } catch (e) {
       if (mounted) {
-        CommonSnackBar.show(context: context, message: '요청 취소에 실패했습니다: $e', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     } finally {
       if (mounted) setState(() => _isPendingTradeAction = false);
@@ -668,7 +668,7 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> with WidgetsBindingObse
       await ChatApi().rejectTradeCompletion(chatRoomId: widget.chatRoomId);
     } catch (e) {
       if (mounted) {
-        CommonSnackBar.show(context: context, message: '거절에 실패했습니다: $e', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     } finally {
       if (mounted) setState(() => _isPendingTradeAction = false);
@@ -690,7 +690,7 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> with WidgetsBindingObse
       }
     } catch (e) {
       if (mounted) {
-        CommonSnackBar.show(context: context, message: '교환 완료 확인에 실패했습니다: $e', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     } finally {
       if (mounted) setState(() => _isPendingTradeAction = false);

--- a/lib/screens/home_tab_screen.dart
+++ b/lib/screens/home_tab_screen.dart
@@ -20,6 +20,7 @@ import 'package:romrom_fe/services/apis/trade_api.dart';
 
 import 'package:romrom_fe/enums/item_condition.dart' as item_cond;
 import 'package:romrom_fe/utils/common_utils.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/app_pressable.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/common_modal.dart';
@@ -330,7 +331,7 @@ class _HomeTabScreenState extends State<HomeTabScreen> {
       await widget.onLoaded?.call();
 
       if (!mounted) return;
-      CommonSnackBar.show(context: context, message: '피드 로딩 실패: $e', type: SnackBarType.error);
+      CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
     }
   }
 
@@ -362,7 +363,7 @@ class _HomeTabScreenState extends State<HomeTabScreen> {
         _isLoadingMore = false;
       });
       if (mounted) {
-        CommonSnackBar.show(context: context, message: '추가 피드 로딩 실패: $e', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     }
   }
@@ -521,7 +522,7 @@ class _HomeTabScreenState extends State<HomeTabScreen> {
     } catch (e) {
       if (!mounted) return;
       debugPrint('거래 요청 확인 오류: $e');
-      CommonSnackBar.show(context: context, message: '교환 요청 확인에 실패했습니다.', type: SnackBarType.error);
+      CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
     }
   }
 

--- a/lib/screens/item_modification_screen.dart
+++ b/lib/screens/item_modification_screen.dart
@@ -4,6 +4,7 @@ import 'package:romrom_fe/enums/snack_bar_type.dart';
 import 'package:romrom_fe/models/apis/objects/item.dart';
 import 'package:romrom_fe/models/apis/requests/item_request.dart';
 import 'package:romrom_fe/services/apis/item_api.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
@@ -44,7 +45,7 @@ class _ItemModificationScreenState extends State<ItemModificationScreen> {
         setState(() {
           _isLoading = false;
         });
-        CommonSnackBar.show(context: context, message: '내 물품 상세 정보 로드 실패: $e', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     }
   }

--- a/lib/screens/item_register_location_screen.dart
+++ b/lib/screens/item_register_location_screen.dart
@@ -7,6 +7,7 @@ import 'package:romrom_fe/enums/snack_bar_type.dart';
 import 'package:romrom_fe/models/app_colors.dart';
 import 'package:romrom_fe/models/location_address.dart';
 import 'package:romrom_fe/services/location_service.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/completion_button.dart';
 import 'package:romrom_fe/widgets/common/current_location_button.dart';
@@ -174,7 +175,7 @@ class _ItemRegisterLocationScreenState extends State<ItemRegisterLocationScreen>
                           if (mounted) {
                             CommonSnackBar.show(
                               context: context,
-                              message: '위치 등록에 실패했습니다: $e',
+                              message: ErrorUtils.getErrorMessage(e),
                               type: SnackBarType.error,
                             );
                           }

--- a/lib/screens/my_page/block_management_screen.dart
+++ b/lib/screens/my_page/block_management_screen.dart
@@ -10,6 +10,7 @@ import 'package:romrom_fe/providers/member_block_provider.dart';
 import 'package:romrom_fe/screens/profile/member_profile_screen.dart';
 import 'package:romrom_fe/services/apis/member_api.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/common_app_bar.dart';
@@ -54,7 +55,7 @@ class _BlockManagementScreenState extends ConsumerState<BlockManagementScreen> {
         setState(() {
           _isLoading = false;
         });
-        CommonSnackBar.show(context: context, message: '차단 목록을 불러오는데 실패했습니다', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     }
   }

--- a/lib/screens/my_page/my_category_settings_screen.dart
+++ b/lib/screens/my_page/my_category_settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:romrom_fe/enums/snack_bar_type.dart';
 import 'package:romrom_fe/enums/item_categories.dart';
 import 'package:romrom_fe/models/app_colors.dart';
 import 'package:romrom_fe/services/apis/member_api.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/category_chip.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/completion_button.dart';
@@ -123,7 +124,7 @@ class _MyCategorySettingsScreenState extends State<MyCategorySettingsScreen> {
                           if (mounted) {
                             CommonSnackBar.show(
                               context: context,
-                              message: '카테고리 저장에 실패했습니다: $e',
+                              message: ErrorUtils.getErrorMessage(e),
                               type: SnackBarType.error,
                             );
                           }

--- a/lib/screens/my_page/my_location_verification_screen.dart
+++ b/lib/screens/my_page/my_location_verification_screen.dart
@@ -10,6 +10,7 @@ import 'package:romrom_fe/models/app_theme.dart';
 import 'package:romrom_fe/models/location_address.dart';
 import 'package:romrom_fe/services/apis/member_api.dart';
 import 'package:romrom_fe/services/location_service.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/completion_button.dart';
 import 'package:romrom_fe/widgets/common/current_location_button.dart';
@@ -97,7 +98,7 @@ class _MyLocationVerificationScreenState extends State<MyLocationVerificationScr
       Navigator.pop(context, true);
     } catch (e) {
       if (!mounted) return;
-      CommonSnackBar.show(context: context, message: '위치 저장에 실패했습니다: $e', type: SnackBarType.error);
+      CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
     } finally {
       if (mounted) setState(() => _isVerifying = false);
     }

--- a/lib/screens/notification_screen.dart
+++ b/lib/screens/notification_screen.dart
@@ -15,6 +15,7 @@ import 'package:romrom_fe/services/apis/notification_api.dart';
 import 'package:romrom_fe/services/notification_permission_service.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/utils/deep_link_router.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/common_modal.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/app_pressable.dart';
@@ -221,7 +222,7 @@ class _NotificationScreenState extends State<NotificationScreen>
     } catch (e) {
       debugPrint('알림 데이터 로드 실패: $e');
       if (mounted) {
-        CommonSnackBar.show(context: context, message: '알림 데이터를 불러오는 데 실패했습니다.', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     } finally {
       if (mounted) {
@@ -260,7 +261,7 @@ class _NotificationScreenState extends State<NotificationScreen>
       CommonSnackBar.show(context: context, message: '모든 알림이 삭제되었습니다.', type: SnackBarType.success);
     } catch (e) {
       if (!mounted) return;
-      CommonSnackBar.show(context: context, message: '알림 삭제에 실패했습니다.', type: SnackBarType.error);
+      CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
     }
   }
 
@@ -323,7 +324,7 @@ class _NotificationScreenState extends State<NotificationScreen>
     } catch (e) {
       debugPrint('알림 설정 변경 실패: $e');
       if (!mounted) return;
-      CommonSnackBar.show(context: context, message: '알림 설정 변경에 실패했습니다.', type: SnackBarType.error);
+      CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
     } finally {
       if (mounted) {
         setState(() {
@@ -346,7 +347,7 @@ class _NotificationScreenState extends State<NotificationScreen>
     } catch (e) {
       debugPrint('딥링크 이동 실패: $e');
       if (mounted) {
-        CommonSnackBar.show(context: context, message: '화면 이동에 실패했습니다.', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     } finally {
       if (mounted) {
@@ -369,7 +370,7 @@ class _NotificationScreenState extends State<NotificationScreen>
       CommonSnackBar.show(context: context, message: '알림이 삭제되었습니다.', type: SnackBarType.success);
     } catch (e) {
       debugPrint('알림 삭제 실패: $e');
-      CommonSnackBar.show(context: context, message: '알림 삭제에 실패했습니다.', type: SnackBarType.error);
+      CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
     }
   }
 

--- a/lib/screens/onboarding/category_selection_step.dart
+++ b/lib/screens/onboarding/category_selection_step.dart
@@ -7,6 +7,7 @@ import 'package:romrom_fe/models/user_info.dart';
 import 'package:romrom_fe/services/apis/member_api.dart';
 import 'package:romrom_fe/services/apis/rom_auth_api.dart';
 import 'package:romrom_fe/services/firebase_service.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/category_chip.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/completion_button.dart';
@@ -85,7 +86,11 @@ class _CategorySelectionStepState extends State<CategorySelectionStep> {
                 } catch (e) {
                   debugPrint("Error: $e");
                   if (mounted) {
-                    CommonSnackBar.show(context: context, message: '카테고리 저장에 실패했습니다: $e', type: SnackBarType.error);
+                    CommonSnackBar.show(
+                      context: context,
+                      message: ErrorUtils.getErrorMessage(e),
+                      type: SnackBarType.error,
+                    );
                   }
                 } finally {
                   if (mounted) {

--- a/lib/screens/onboarding/location_verification_step.dart
+++ b/lib/screens/onboarding/location_verification_step.dart
@@ -10,6 +10,7 @@ import 'package:romrom_fe/models/app_theme.dart';
 import 'package:romrom_fe/models/location_address.dart';
 import 'package:romrom_fe/services/apis/member_api.dart';
 import 'package:romrom_fe/services/location_service.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/completion_button.dart';
 import 'package:romrom_fe/widgets/common/current_location_button.dart';
@@ -96,7 +97,7 @@ class _LocationVerificationStepState extends State<LocationVerificationStep> {
       widget.onNext();
     } catch (e) {
       if (!mounted) return;
-      CommonSnackBar.show(context: context, message: '위치 저장에 실패했습니다: $e', type: SnackBarType.error);
+      CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
     } finally {
       if (mounted) setState(() => _isVerifying = false);
     }

--- a/lib/screens/onboarding/term_agreement_step.dart
+++ b/lib/screens/onboarding/term_agreement_step.dart
@@ -11,6 +11,7 @@ import 'package:romrom_fe/models/user_info.dart';
 import 'package:romrom_fe/screens/onboarding/term_detail_screen.dart';
 import 'package:romrom_fe/services/apis/member_api.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/completion_button.dart';
 import 'package:romrom_fe/widgets/common/loading_indicator.dart';
@@ -101,7 +102,7 @@ class _TermAgreementStepState extends State<TermAgreementStep> {
     } catch (e) {
       debugPrint('약관 동의 처리 실패: $e');
       if (mounted) {
-        CommonSnackBar.show(context: context, message: '오류가 발생했습니다. 다시 시도해주세요.', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     } finally {
       if (mounted) {

--- a/lib/screens/profile/member_profile_screen.dart
+++ b/lib/screens/profile/member_profile_screen.dart
@@ -97,7 +97,7 @@ class _MemberProfileScreenState extends State<MemberProfileScreen> {
           _isLoading = false;
           _hasError = true;
         });
-        CommonSnackBar.show(context: context, message: '프로필을 불러오는데 실패했습니다', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     }
   }

--- a/lib/screens/register_tab_screen.dart
+++ b/lib/screens/register_tab_screen.dart
@@ -559,7 +559,7 @@ class _RegisterTabScreenState extends State<RegisterTabScreen> with TickerProvid
                       if (mounted) {
                         CommonSnackBar.show(
                           context: context,
-                          message: '물품 개수 확인에 실패했습니다. 다시 시도해주세요.',
+                          message: ErrorUtils.getErrorMessage(e),
                           type: SnackBarType.error,
                         );
                       }

--- a/lib/screens/request_management_tab_screen.dart
+++ b/lib/screens/request_management_tab_screen.dart
@@ -22,6 +22,7 @@ import 'package:romrom_fe/screens/item_modification_screen.dart';
 import 'package:romrom_fe/services/apis/item_api.dart';
 import 'package:romrom_fe/services/apis/trade_api.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/completed_toggle_switch.dart';
 import 'package:romrom_fe/widgets/common/loading_indicator.dart';
@@ -136,7 +137,7 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
       if (!mounted) return;
 
       if (!mounted) return;
-      CommonSnackBar.show(context: context, message: '피드 로딩 실패: $e', type: SnackBarType.error);
+      CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
     }
     setState(() {
       _isLoading = false;
@@ -427,7 +428,11 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
                   } catch (e) {
                     debugPrint('요청 취소 실패: $e');
                     if (mounted) {
-                      CommonSnackBar.show(context: context, message: '요청 취소에 실패했습니다', type: SnackBarType.error);
+                      CommonSnackBar.show(
+                        context: context,
+                        message: ErrorUtils.getErrorMessage(e),
+                        type: SnackBarType.error,
+                      );
                     }
                   }
                 }
@@ -873,7 +878,11 @@ class _RequestManagementTabScreenState extends State<RequestManagementTabScreen>
                           } catch (e) {
                             debugPrint('요청 취소 실패: $e');
                             if (mounted) {
-                              CommonSnackBar.show(context: context, message: '요청 삭제에 실패했습니다', type: SnackBarType.error);
+                              CommonSnackBar.show(
+                                context: context,
+                                message: ErrorUtils.getErrorMessage(e),
+                                type: SnackBarType.error,
+                              );
                             }
                           }
                         }

--- a/lib/screens/search_range_setting_screen.dart
+++ b/lib/screens/search_range_setting_screen.dart
@@ -9,6 +9,7 @@ import 'package:romrom_fe/models/app_theme.dart';
 import 'package:romrom_fe/screens/my_page/my_location_verification_screen.dart';
 import 'package:romrom_fe/services/apis/member_api.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/current_location_button.dart';
 import 'package:romrom_fe/widgets/common/loading_indicator.dart';
@@ -203,7 +204,7 @@ class _SearchRangeSettingScreenState extends State<SearchRangeSettingScreen> {
     } catch (e) {
       debugPrint('탐색 범위 저장 실패: $e');
       if (mounted) {
-        CommonSnackBar.show(context: context, message: '탐색 범위 저장에 실패했습니다', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     }
   }

--- a/lib/screens/trade_complete_partner_select_screen.dart
+++ b/lib/screens/trade_complete_partner_select_screen.dart
@@ -7,6 +7,7 @@ import 'package:romrom_fe/models/app_colors.dart';
 import 'package:romrom_fe/models/app_theme.dart';
 import 'package:romrom_fe/services/apis/chat_api.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/utils/item_label_utils.dart';
 import 'package:romrom_fe/widgets/common/cached_image.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
@@ -56,7 +57,7 @@ class _TradeCompletePartnerSelectScreenState extends State<TradeCompletePartnerS
     } catch (e) {
       if (mounted) {
         setState(() => _isLoading = false);
-        CommonSnackBar.show(context: context, message: '채팅 목록을 불러오지 못했습니다.', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     }
   }

--- a/lib/screens/trade_request_screen.dart
+++ b/lib/screens/trade_request_screen.dart
@@ -137,7 +137,7 @@ class _TradeRequestScreenState extends State<TradeRequestScreen> {
 
       setState(() => _isLoading = false);
 
-      CommonSnackBar.show(context: context, message: '물품 목록을 불러오는데 실패했습니다.', type: SnackBarType.error);
+      CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
     }
   }
 

--- a/lib/widgets/profile/profile_overview_section.dart
+++ b/lib/widgets/profile/profile_overview_section.dart
@@ -9,6 +9,7 @@ import 'package:romrom_fe/models/app_theme.dart';
 import 'package:romrom_fe/screens/my_page/profile_image_crop_screen.dart';
 import 'package:romrom_fe/services/apis/image_api.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/user_profile_circular_avatar.dart';
@@ -119,7 +120,7 @@ class _ProfileOverviewSectionState extends State<ProfileOverviewSection> {
         }
       } catch (e) {
         if (context.mounted) {
-          CommonSnackBar.show(context: context, message: '이미지 업로드에 실패했습니다: $e', type: SnackBarType.error);
+          CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
         }
         if (mounted) widget.onUploadFailed?.call();
       } finally {
@@ -127,7 +128,7 @@ class _ProfileOverviewSectionState extends State<ProfileOverviewSection> {
       }
     } catch (e) {
       if (context.mounted) {
-        CommonSnackBar.show(context: context, message: '이미지 선택에 실패했습니다: $e', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     }
   }

--- a/lib/widgets/register_input_form.dart
+++ b/lib/widgets/register_input_form.dart
@@ -35,6 +35,7 @@ import 'package:romrom_fe/widgets/register_option_chip.dart';
 import 'package:romrom_fe/widgets/register_text_field.dart';
 import 'package:romrom_fe/widgets/skeletons/register_input_form_skeleton.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
+import 'package:romrom_fe/utils/error_utils.dart';
 import 'package:romrom_fe/widgets/common/cached_image.dart';
 
 /// 물품 등록 입력 폼 위젯
@@ -124,7 +125,7 @@ class _RegisterInputFormState extends State<RegisterInputForm> {
       });
     } catch (e) {
       if (context.mounted) {
-        CommonSnackBar.show(context: context, message: '이미지 선택에 실패했습니다: $e', type: SnackBarType.error);
+        CommonSnackBar.show(context: context, message: ErrorUtils.getErrorMessage(e), type: SnackBarType.error);
       }
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1107,10 +1107,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1672,10 +1672,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1107,10 +1107,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1672,10 +1672,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- 백엔드 API 요청 후 발생하는 에러를 하드코딩된 문자열 대신 `ErrorUtils.getErrorMessage(e)`로 통일
- 20개 파일, 31개 catch 블록 수정
- `dart format` + `flutter analyze` 통과 확인

## 수정 파일
`screens/` 7개, `screens/my_page/` 3개, `screens/onboarding/` 3개, `screens/profile/` 1개, `screens/chat_room_screen.dart`, `screens/request_management_tab_screen.dart`, `screens/notification_screen.dart`, `widgets/register_input_form.dart`, `widgets/profile/profile_overview_section.dart`

## Test plan
- [ ] 각 화면에서 API 에러 발생 시 스낵바에 올바른 한국어 메시지 표시 확인
- [ ] 네트워크 오류 상황에서 unknown 에러 메시지 표시 확인
- [ ] `flutter analyze` 이슈 없음 확인

Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 앱 전역의 에러 메시지 표시 방식을 통일하여 더욱 일관되고 명확한 오류 정보를 제공합니다. 이미지 업로드, 위치 등록, 데이터 로드 등 다양한 기능에서 발생하는 오류 시 사용자 친화적인 메시지를 표시하도록 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-ROMROM/RomRom-FE/pull/851)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->