### PR TITLE
유저 피드백 및 평가 모달 구현

### DIFF
--- a/docs/superpowers/plans/2026-05-24-app-review-popup.md
+++ b/docs/superpowers/plans/2026-05-24-app-review-popup.md
@@ -1,0 +1,533 @@
+# 앱 리뷰 팝업 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 2단계 프리-스크린 팝업으로 긍정 유저만 필터링해 iOS/Android 스토어 리뷰를 유도하는 시스템 구현
+
+**Architecture:** `AppReviewService`가 SharedPreferences 상태 관리 + 트리거 판단 담당. `AppReviewPopup`이 CommonModal 2단계 시퀀스 제어. 트리거는 거래 완료(`TradeReviewScreen`) 우선, 앱 종료(`MainScreen PopScope`) 폴백.
+
+**Tech Stack:** Flutter, `in_app_review ^2.0.9`, `shared_preferences ^2.5.2` (기존), `url_launcher ^6.3.2` (기존)
+
+---
+
+## 파일 구조
+
+| 파일 | 작업 | 역할 |
+|------|------|------|
+| `lib/services/app_review_service.dart` | 신규 생성 | SharedPreferences CRUD, 트리거 판단, in_app_review 호출 |
+| `lib/widgets/common/app_review_popup.dart` | 신규 생성 | 2단계 CommonModal 시퀀스 제어 |
+| `pubspec.yaml` | 수정 | `in_app_review` 패키지 추가 |
+| `lib/screens/trade_review_screen.dart` | 수정 | 거래 완료 후 팝업 트리거 |
+| `lib/screens/main_screen.dart` | 수정 | 앱 실행 횟수 기록 + PopScope 종료 트리거 |
+
+---
+
+## Task 1: `in_app_review` 패키지 추가
+
+**Files:**
+- Modify: `pubspec.yaml`
+
+- [ ] **Step 1: pubspec.yaml에 패키지 추가**
+
+`dependencies:` 블록에 추가:
+```yaml
+  in_app_review: ^2.0.9
+```
+
+- [ ] **Step 2: pub get 실행**
+
+```bash
+source ~/.zshrc && flutter pub get
+```
+
+Expected: `Got dependencies!` 출력, 에러 없음
+
+- [ ] **Step 3: 빌드 확인**
+
+```bash
+source ~/.zshrc && flutter analyze --no-fatal-infos 2>&1 | tail -5
+```
+
+Expected: `No issues found!` 또는 기존 warning만 있고 새 에러 없음
+
+---
+
+## Task 2: `AppReviewService` 구현
+
+**Files:**
+- Create: `lib/services/app_review_service.dart`
+
+- [ ] **Step 1: 서비스 파일 생성**
+
+```dart
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:in_app_review/in_app_review.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// 앱 리뷰 팝업 상태 관리 및 트리거 판단 서비스
+/// SharedPreferences 기반 로컬 저장, 백엔드 연동 없음
+class AppReviewService {
+  static final AppReviewService _instance = AppReviewService._internal();
+  factory AppReviewService() => _instance;
+  AppReviewService._internal();
+
+  // SharedPreferences 키
+  static const String _kDisabled = 'review_disabled';
+  static const String _kLastShown = 'review_last_shown';
+  static const String _kShownCount = 'review_shown_count';
+  static const String _kLaunchCount = 'app_launch_count';
+  static const String _kFirstLaunchDate = 'app_first_launch_date';
+  static const String _kTradeCompleteCount = 'trade_complete_count';
+
+  static const Duration _kCooldown = Duration(days: 14);
+  static const int _kMaxShownCount = 3;
+  static const int _kMinLaunchCount = 2;
+  static const int _kMinUsageDays = 3;
+
+  static const String _kIosStoreUrl = 'https://apps.apple.com/app/id6748823976';
+  static const String _kAndroidStoreUrl =
+      'https://play.google.com/store/apps/details?id=com.alom.romrom';
+
+  /// 앱 실행 시 호출 — 실행 횟수 +1, 첫 실행일 기록
+  Future<void> onAppLaunch() async {
+    final prefs = await SharedPreferences.getInstance();
+
+    // 첫 실행일 기록 (한 번만)
+    if (!prefs.containsKey(_kFirstLaunchDate)) {
+      await prefs.setInt(
+        _kFirstLaunchDate,
+        DateTime.now().millisecondsSinceEpoch,
+      );
+    }
+
+    final count = prefs.getInt(_kLaunchCount) ?? 0;
+    await prefs.setInt(_kLaunchCount, count + 1);
+    debugPrint('[AppReview] 앱 실행 횟수: ${count + 1}');
+  }
+
+  /// 거래 완료 시 호출 — 거래 완료 횟수 +1
+  Future<void> onTradeComplete() async {
+    final prefs = await SharedPreferences.getInstance();
+    final count = prefs.getInt(_kTradeCompleteCount) ?? 0;
+    await prefs.setInt(_kTradeCompleteCount, count + 1);
+    debugPrint('[AppReview] 거래 완료 횟수: ${count + 1}');
+  }
+
+  /// 팝업 표시 여부 판단
+  /// 거래 완료 트리거: tradeTriggered = true
+  /// 종료 트리거: tradeTriggered = false
+  Future<bool> shouldShow({bool tradeTriggered = false}) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    // 영구 비활성
+    if (prefs.getBool(_kDisabled) ?? false) {
+      debugPrint('[AppReview] 영구 비활성 → 표시 안 함');
+      return false;
+    }
+
+    // 노출 횟수 초과 → 영구 비활성 처리
+    final shownCount = prefs.getInt(_kShownCount) ?? 0;
+    if (shownCount >= _kMaxShownCount) {
+      await prefs.setBool(_kDisabled, true);
+      debugPrint('[AppReview] 노출 3회 초과 → 영구 비활성');
+      return false;
+    }
+
+    // 쿨타임 체크
+    final lastShownMs = prefs.getInt(_kLastShown);
+    if (lastShownMs != null) {
+      final lastShown = DateTime.fromMillisecondsSinceEpoch(lastShownMs);
+      if (DateTime.now().difference(lastShown) < _kCooldown) {
+        debugPrint('[AppReview] 쿨타임 미경과 → 표시 안 함');
+        return false;
+      }
+    }
+
+    if (tradeTriggered) {
+      // 거래 완료 트리거: 거래 1회 이상 + 앱 사용 3일 이상
+      final tradeCount = prefs.getInt(_kTradeCompleteCount) ?? 0;
+      final firstLaunchMs = prefs.getInt(_kFirstLaunchDate);
+      if (tradeCount < 1 || firstLaunchMs == null) return false;
+
+      final firstLaunch = DateTime.fromMillisecondsSinceEpoch(firstLaunchMs);
+      final usageDays = DateTime.now().difference(firstLaunch).inDays;
+      final ok = usageDays >= _kMinUsageDays;
+      debugPrint('[AppReview] 거래 트리거: 거래=$tradeCount, 사용일수=$usageDays → ${ok ? '표시' : '미충족'}');
+      return ok;
+    } else {
+      // 종료 트리거: 앱 실행 2회 이상
+      final launchCount = prefs.getInt(_kLaunchCount) ?? 0;
+      final ok = launchCount >= _kMinLaunchCount;
+      debugPrint('[AppReview] 종료 트리거: 실행=$launchCount → ${ok ? '표시' : '미충족'}');
+      return ok;
+    }
+  }
+
+  /// 팝업 노출 기록
+  Future<void> markShown() async {
+    final prefs = await SharedPreferences.getInstance();
+    final count = prefs.getInt(_kShownCount) ?? 0;
+    await prefs.setInt(_kShownCount, count + 1);
+    await prefs.setInt(_kLastShown, DateTime.now().millisecondsSinceEpoch);
+    debugPrint('[AppReview] 노출 기록: ${count + 1}회');
+  }
+
+  /// [리뷰 남기기] 클릭 시 — 영구 비활성 + 네이티브 리뷰 요청
+  Future<void> requestReviewAndDisable() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_kDisabled, true);
+    debugPrint('[AppReview] 영구 비활성 처리');
+
+    await _requestReview();
+  }
+
+  /// in_app_review 호출, 실패 시 스토어 링크 폴백
+  Future<void> _requestReview() async {
+    final inAppReview = InAppReview.instance;
+    try {
+      if (await inAppReview.isAvailable()) {
+        await inAppReview.requestReview();
+        debugPrint('[AppReview] 네이티브 리뷰 다이얼로그 호출 성공');
+        return;
+      }
+    } catch (e) {
+      debugPrint('[AppReview] 네이티브 리뷰 실패: $e');
+    }
+    // 폴백: 스토어 링크 열기
+    await _openStoreLink();
+  }
+
+  Future<void> _openStoreLink() async {
+    final url = Uri.parse(Platform.isIOS ? _kIosStoreUrl : _kAndroidStoreUrl);
+    try {
+      if (await canLaunchUrl(url)) {
+        await launchUrl(url, mode: LaunchMode.externalApplication);
+        debugPrint('[AppReview] 스토어 링크 열기 성공');
+      }
+    } catch (e) {
+      debugPrint('[AppReview] 스토어 링크 열기 실패: $e');
+    }
+  }
+
+  /// [별로예요] / [나중에] / 닫기 — 14일 쿨타임만 기록
+  Future<void> markDismissed() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_kLastShown, DateTime.now().millisecondsSinceEpoch);
+    debugPrint('[AppReview] 닫기 기록 (14일 쿨타임)');
+  }
+}
+```
+
+- [ ] **Step 2: 린트 확인**
+
+```bash
+source ~/.zshrc && flutter analyze lib/services/app_review_service.dart
+```
+
+Expected: 에러 없음
+
+---
+
+## Task 3: `AppReviewPopup` 위젯 구현
+
+**Files:**
+- Create: `lib/widgets/common/app_review_popup.dart`
+
+- [ ] **Step 1: 팝업 위젯 파일 생성**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:romrom_fe/services/app_review_service.dart';
+import 'package:romrom_fe/widgets/common/common_modal.dart';
+
+/// 앱 리뷰 유도 2단계 팝업 시퀀스
+/// Step 1: "잘 이용하고 계신가요?" 감성 질문
+/// Step 2: [좋아요] 선택 시 → "스토어 리뷰 남겨주실래요?"
+class AppReviewPopup {
+  /// 팝업 시퀀스 실행
+  /// context가 mounted 상태인지 호출 전 반드시 확인할 것
+  static Future<void> show(
+    BuildContext context,
+    AppReviewService service,
+  ) async {
+    // 노출 기록 (Step 1이 뜨는 시점)
+    await service.markShown();
+
+    if (!context.mounted) return;
+
+    // Step 1: 감성 질문 팝업
+    final isPositive = await _showStep1(context);
+
+    if (!isPositive) {
+      // [별로예요] → 14일 쿨타임 (markShown에서 이미 last_shown 기록됨)
+      return;
+    }
+
+    if (!context.mounted) return;
+
+    // Step 2: 리뷰 유도 팝업
+    final wantsReview = await _showStep2(context);
+
+    if (wantsReview) {
+      await service.requestReviewAndDisable();
+    }
+    // [나중에] 선택 시: markShown에서 already 기록됨, 추가 처리 없음
+  }
+
+  /// Step 1: "RomRom을 잘 이용하고 계신가요?"
+  /// 반환값: true = [좋아요!], false = [별로예요] or 닫기
+  static Future<bool> _showStep1(BuildContext context) async {
+    bool isPositive = false;
+    await CommonModal.confirm(
+      context: context,
+      message: 'RomRom을 잘 이용하고 계신가요?\n소중한 의견이 앱 개선에 도움이 됩니다 😊',
+      cancelText: '별로예요',
+      confirmText: '좋아요!',
+      onCancel: () {
+        isPositive = false;
+        Navigator.of(context).pop();
+      },
+      onConfirm: () {
+        isPositive = true;
+        Navigator.of(context).pop();
+      },
+    );
+    return isPositive;
+  }
+
+  /// Step 2: "스토어 리뷰를 남겨주실래요?"
+  /// 반환값: true = [리뷰 남기기], false = [나중에] or 닫기
+  static Future<bool> _showStep2(BuildContext context) async {
+    bool wantsReview = false;
+    await CommonModal.confirm(
+      context: context,
+      message: '별점 한 줄이 큰 힘이 됩니다! ⭐\n스토어에 리뷰를 남겨주실래요?',
+      cancelText: '나중에',
+      confirmText: '리뷰 남기기',
+      onCancel: () {
+        wantsReview = false;
+        Navigator.of(context).pop();
+      },
+      onConfirm: () {
+        wantsReview = true;
+        Navigator.of(context).pop();
+      },
+    );
+    return wantsReview;
+  }
+}
+```
+
+- [ ] **Step 2: CommonModal.confirm 팩토리 시그니처 확인**
+
+```bash
+source ~/.zshrc && grep -A 20 "static.*confirm" /Users/suhsaechan/Desktop/Programming/project/RomRom-FE/lib/widgets/common/common_modal.dart | head -25
+```
+
+`confirm` 팩토리가 없으면 아래 Step 3으로 이동. 있으면 Step 4로 건너뜀.
+
+- [ ] **Step 3: (confirm 없는 경우만) CommonModal 팩토리 확인 후 맞는 메서드로 교체**
+
+`common_modal.dart`의 실제 팩토리 메서드명 확인:
+```bash
+source ~/.zshrc && grep "static.*Future\|static.*show\|factory" /Users/suhsaechan/Desktop/Programming/project/RomRom-FE/lib/widgets/common/common_modal.dart
+```
+
+출력된 팩토리명으로 `_showStep1`, `_showStep2`의 `CommonModal.confirm(...)` 호출부를 실제 메서드명으로 교체.
+
+- [ ] **Step 4: 린트 확인**
+
+```bash
+source ~/.zshrc && flutter analyze lib/widgets/common/app_review_popup.dart
+```
+
+Expected: 에러 없음
+
+---
+
+## Task 4: `MainScreen` — 앱 실행 횟수 기록
+
+**Files:**
+- Modify: `lib/screens/main_screen.dart`
+
+- [ ] **Step 1: import 추가**
+
+`main_screen.dart` 상단 import 목록에 추가:
+```dart
+import 'package:romrom_fe/services/app_review_service.dart';
+```
+
+- [ ] **Step 2: initState에서 onAppLaunch 호출**
+
+`_MainScreenState.initState()` 내 `WidgetsBinding.instance.addPostFrameCallback` 블록에 추가:
+
+```dart
+WidgetsBinding.instance.addPostFrameCallback((_) async {
+  if (!mounted) return;
+  // 기존 코드 유지
+  await _syncNotificationPermissionToBackend();
+  // 앱 실행 횟수 기록
+  await AppReviewService().onAppLaunch();
+});
+```
+
+- [ ] **Step 3: 린트 확인**
+
+```bash
+source ~/.zshrc && flutter analyze lib/screens/main_screen.dart
+```
+
+Expected: 에러 없음
+
+---
+
+## Task 5: `MainScreen` — 앱 종료 시도 시 팝업 트리거
+
+**Files:**
+- Modify: `lib/screens/main_screen.dart`
+
+- [ ] **Step 1: import 추가**
+
+```dart
+import 'package:romrom_fe/widgets/common/app_review_popup.dart';
+```
+
+- [ ] **Step 2: _MainScreenState에 종료 팝업 핸들러 추가**
+
+`_MainScreenState` 클래스에 메서드 추가:
+
+```dart
+/// 앱 종료 시도 시 리뷰 팝업 조건 체크
+Future<bool> _onWillPop() async {
+  final service = AppReviewService();
+  if (await service.shouldShow(tradeTriggered: false)) {
+    if (mounted) {
+      await AppReviewPopup.show(context, service);
+    }
+  }
+  return true; // 팝업 여부와 관계없이 종료 허용
+}
+```
+
+- [ ] **Step 3: build 메서드에 PopScope 래핑 확인 및 추가**
+
+`MainScreen.build()`에서 최상위 위젯을 `PopScope`로 래핑:
+
+```dart
+@override
+Widget build(BuildContext context) {
+  return PopScope(
+    canPop: false,
+    onPopInvokedWithResult: (didPop, result) async {
+      if (didPop) return;
+      final shouldPop = await _onWillPop();
+      if (shouldPop && mounted) {
+        Navigator.of(context).pop(result);
+      }
+    },
+    child: Scaffold(
+      // 기존 Scaffold 내용 그대로 유지
+      ...
+    ),
+  );
+}
+```
+
+> 주의: 기존에 `PopScope`나 `WillPopScope`가 이미 있으면 새로 추가하지 말고 기존 콜백에 `_onWillPop()` 호출을 합쳐야 함. 먼저 확인:
+> ```bash
+> grep -n "PopScope\|WillPopScope" lib/screens/main_screen.dart
+> ```
+
+- [ ] **Step 4: 린트 확인**
+
+```bash
+source ~/.zshrc && flutter analyze lib/screens/main_screen.dart
+```
+
+Expected: 에러 없음
+
+---
+
+## Task 6: `TradeReviewScreen` — 거래 완료 후 팝업 트리거
+
+**Files:**
+- Modify: `lib/screens/trade_review_screen.dart`
+
+- [ ] **Step 1: import 추가**
+
+```dart
+import 'package:romrom_fe/services/app_review_service.dart';
+import 'package:romrom_fe/widgets/common/app_review_popup.dart';
+```
+
+- [ ] **Step 2: onTradeComplete 호출 + 팝업 트리거**
+
+`_submit()` 메서드에서 `context.navigateTo(...)` 직전에 추가:
+
+```dart
+// 거래 완료 횟수 기록 및 리뷰 팝업 조건 체크
+final reviewService = AppReviewService();
+await reviewService.onTradeComplete();
+
+if (!mounted) return;
+
+// MainScreen으로 이동 전에 팝업 표시 (navigateTo 이후엔 context 무효)
+if (await reviewService.shouldShow(tradeTriggered: true)) {
+  if (mounted) {
+    await AppReviewPopup.show(context, reviewService);
+  }
+}
+
+if (!mounted) return;
+context.navigateTo(
+  screen: const MainScreen(),
+  type: NavigationTypes.pushAndRemoveUntil,
+  predicate: (route) => false,
+);
+```
+
+- [ ] **Step 3: 린트 확인**
+
+```bash
+source ~/.zshrc && flutter analyze lib/screens/trade_review_screen.dart
+```
+
+Expected: 에러 없음
+
+---
+
+## Task 7: 전체 포맷 + 최종 분석
+
+**Files:**
+- 모든 수정 파일
+
+- [ ] **Step 1: 전체 포맷 적용**
+
+```bash
+source ~/.zshrc && dart format --line-length=120 .
+```
+
+- [ ] **Step 2: 전체 린트 분석**
+
+```bash
+source ~/.zshrc && flutter analyze
+```
+
+Expected: `No issues found!` 또는 기존 warning만 있고 신규 에러 없음. 에러 발생 시 수정 후 재실행.
+
+---
+
+## 검증 체크리스트 (수동)
+
+시뮬레이터 또는 실기기에서 확인:
+
+- [ ] 앱 실행 2회 + 홈에서 뒤로가기 → Step 1 팝업 노출
+- [ ] [좋아요!] → Step 2 팝업 노출
+- [ ] [리뷰 남기기] → 네이티브 다이얼로그 또는 스토어 링크 열림
+- [ ] 팝업 노출 후 14일 내 재실행 → 팝업 안 뜸
+- [ ] 거래 완료 + 앱 사용 3일 → 거래 완료 직후 팝업 노출
+- [ ] [별로예요] → 팝업 닫힘, 14일 후 재노출
+- [ ] 3회 노출 후 → 영구 비활성

--- a/docs/superpowers/specs/2026-05-24-app-review-popup-design.md
+++ b/docs/superpowers/specs/2026-05-24-app-review-popup-design.md
@@ -1,0 +1,165 @@
+# 앱 리뷰 팝업 구현 스펙
+
+**이슈:** [#811](https://github.com/TEAM-ROMROM/RomRom-FE/issues/811)  
+**작성일:** 2026-05-24
+
+---
+
+## 개요
+
+스토어 별점/리뷰 유도를 위한 2단계 팝업 시스템 구현.  
+긍정적 사용자만 필터링해 스토어 리뷰로 유도하고, 부정적 사용자는 쿨타임 처리.
+
+---
+
+## 플로우
+
+```
+[트리거 조건 충족]
+        ↓
+  [Step 1 팝업]
+  "RomRom을 잘 이용하고 계신가요?"
+  [좋아요! 😊]         [별로예요 😞]
+       ↓                     ↓
+  [Step 2 팝업]          14일 쿨타임
+  "스토어 리뷰를 남겨주실래요?"
+  [리뷰 남기기 ✍️]      [나중에]
+       ↓                     ↓
+  in_app_review           14일 쿨타임
+  네이티브 다이얼로그
+  (실패 시 스토어 링크 폴백)
+       ↓
+   영구 비활성
+```
+
+---
+
+## 트리거 조건
+
+둘 중 하나 충족 시 팝업 표시 (우선순위 순):
+
+### 1순위 — 거래 완료 후
+- 거래 완료(`TradeReviewScreen` 완료 콜백) 직후
+- 앱 사용 누적 3일 이상 (`app_first_launch_date` 기준)
+
+### 2순위 (폴백) — 앱 종료 시도 시
+- 앱 접속 누적 2회 이상
+- `PopScope` onPopInvokedWithResult 콜백에서 체크
+
+### 공통 필터
+- `review_disabled == true` → 팝업 안 띄움 (영구 비활성)
+- `review_last_shown` 기준 14일 미경과 → 팝업 안 띄움
+- `review_shown_count >= 3` → 영구 비활성 처리 후 팝업 안 띄움
+
+---
+
+## 상태 관리 (SharedPreferences)
+
+| 키 | 타입 | 설명 |
+|----|------|------|
+| `review_disabled` | bool | 영구 비활성 여부 |
+| `review_last_shown` | int | 마지막 노출 Unix timestamp (ms) |
+| `review_shown_count` | int | 누적 팝업 노출 횟수 |
+| `app_launch_count` | int | 앱 접속 누적 횟수 |
+| `app_first_launch_date` | int | 첫 실행 Unix timestamp (ms) |
+| `trade_complete_count` | int | 거래 완료 누적 횟수 |
+
+---
+
+## 유저 행동별 상태 변화
+
+| 행동 | 상태 변화 |
+|------|----------|
+| Step 1 [좋아요!] | `review_shown_count++`, `review_last_shown = now` |
+| Step 1 [별로예요] | `review_shown_count++`, `review_last_shown = now` |
+| Step 2 [리뷰 남기기] | `review_disabled = true` (영구 비활성) |
+| Step 2 [나중에] | `review_last_shown = now` (14일 쿨타임) |
+| 팝업 외부 탭/닫기 | `review_last_shown = now` (14일 쿨타임) |
+| `shown_count >= 3` | `review_disabled = true` (영구 비활성) |
+
+---
+
+## 컴포넌트 설계
+
+### `AppReviewService` (신규)
+위치: `lib/services/app_review_service.dart`
+
+책임:
+- SharedPreferences CRUD (모든 리뷰 팝업 상태)
+- 팝업 표시 여부 판단 (`shouldShow()`)
+- `in_app_review` 호출 + 스토어 링크 폴백
+- 앱 실행 횟수, 첫 실행일 기록
+
+```dart
+class AppReviewService {
+  Future<bool> shouldShow();          // 팝업 표시 여부 판단
+  Future<void> markShown();           // 노출 기록 (shown_count++, last_shown)
+  Future<void> markPermanentlyDone(); // 영구 비활성
+  Future<void> requestReview();       // in_app_review → 폴백
+  Future<void> incrementLaunchCount(); // 앱 실행 시 호출
+  Future<void> incrementTradeCount(); // 거래 완료 시 호출
+}
+```
+
+### `AppReviewPopup` (신규)
+위치: `lib/widgets/common/app_review_popup.dart`
+
+책임:
+- Step 1/2 팝업 순서 제어
+- `CommonModal` 팩토리 메서드 호출
+- `AppReviewService` 콜백 처리
+
+```dart
+class AppReviewPopup {
+  // static 메서드로 팝업 시퀀스 실행
+  static Future<void> show(BuildContext context, AppReviewService service);
+}
+```
+
+### 트리거 포인트 (기존 파일 수정)
+
+| 파일 | 수정 내용 |
+|------|----------|
+| `lib/main.dart` | 앱 시작 시 `incrementLaunchCount()` 호출 |
+| `lib/screens/trade_review_screen.dart` | 거래 완료 콜백에서 `AppReviewPopup.show()` 호출 |
+| 홈 화면 최상위 Scaffold | `PopScope` → 앱 종료 시도 시 `AppReviewPopup.show()` 호출 |
+
+---
+
+## 의존성
+
+| 패키지 | 용도 | 현재 상태 |
+|--------|------|----------|
+| `in_app_review` | 네이티브 리뷰 다이얼로그 | **신규 추가 필요** |
+| `shared_preferences` | 상태 저장 | 이미 있음 (`^2.5.2`) |
+| `url_launcher` | 스토어 링크 폴백 | 이미 있음 (`^6.3.2`) |
+
+`pubspec.yaml`에 추가:
+```yaml
+in_app_review: ^2.0.9
+```
+
+---
+
+## 스토어 링크 (폴백용)
+
+- **iOS (App Store):** `https://apps.apple.com/app/id6748823976`
+- **Android (Play Store):** `https://play.google.com/store/apps/details?id=com.alom.romrom`
+
+플랫폼 분기: `Platform.isIOS` / `Platform.isAndroid`
+
+---
+
+## 에러 처리
+
+- `in_app_review.isAvailable()` → false이면 스토어 링크로 폴백
+- 스토어 링크 `canLaunchUrl` 실패 시 조용히 무시 (팝업만 닫기)
+- `BuildContext` unmounted 체크 필수 (비동기 콜백 이후)
+
+---
+
+## 구현 범위 외
+
+- 백엔드 연동 없음 (순수 로컬 상태)
+- 별점 수집/분석 서버 전송 없음
+- 커스텀 별점 UI 없음 (네이티브 다이얼로그 사용)

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -134,6 +134,8 @@ PODS:
     - GTMSessionFetcher/Core
   - image_picker_ios (0.0.1):
     - Flutter
+  - in_app_review (2.0.0):
+    - Flutter
   - integration_test (0.0.1):
     - Flutter
   - kakao_flutter_sdk_common (1.10.0):
@@ -190,6 +192,7 @@ DEPENDENCIES:
   - google_mobile_ads (from `.symlinks/plugins/google_mobile_ads/ios`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - in_app_review (from `.symlinks/plugins/in_app_review/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - kakao_flutter_sdk_common (from `.symlinks/plugins/kakao_flutter_sdk_common/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -259,6 +262,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/google_sign_in_ios/darwin"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
+  in_app_review:
+    :path: ".symlinks/plugins/in_app_review/ios"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
   kakao_flutter_sdk_common:
@@ -318,6 +323,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
+  in_app_review: 7dd1ea365263f834b8464673f9df72c80c17c937
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   kakao_flutter_sdk_common: 682b3606698f87467788598dc2dc09d4e6867fbd
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -285,15 +285,15 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  app_links: 585674be3c6661708e6cd794ab4f39fb9d8356f9
+  app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
+  device_info_plus: 71ffc6ab7634ade6267c7a93088ed7e4f74e5896
   Firebase: 9a58fdbc9d8655ed7b79a19cf9690bb007d3d46d
-  firebase_auth: e7aec07fcada64e296cf237a61df9660e52842c2
-  firebase_core: 8d5e24676350f15dd111aa59a88a1ae26605f9ba
-  firebase_messaging: 834cfc0887393d3108cdb19da8e57655c54fd0e4
+  firebase_auth: e9031a1dbe04a90d98e8d11ff2302352a1c6d9e8
+  firebase_core: ee30637e6744af8e0c12a6a1e8a9718506ec2398
+  firebase_messaging: 343de01a8d3e18b60df0c6d37f7174c44ae38e02
   FirebaseAppCheckInterop: ba3dc604a89815379e61ec2365101608d365cf7d
   FirebaseAuth: 4c289b1a43f5955283244a55cf6bd616de344be5
   FirebaseAuthInterop: 95363fe96493cb4f106656666a0768b420cba090
@@ -303,38 +303,38 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 6a14ab3d694ebd9f839c48d330da5547e9ca9dc0
   FirebaseMessaging: 7f42cfd10ec64181db4e01b305a613791c8e782c
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_local_notifications: ff50f8405aaa0ccdc7dcfb9022ca192e8ad9688f
-  flutter_naver_map: a1f6df83f663d9770e01624ba97a2d34c4fe349b
-  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
-  geocoding_ios: eafacae6ad11a1eb56681f7d11df602a5fd49416
-  geolocator_apple: 66b711889fd333205763b83c9dcf0a57a28c7afd
+  flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
+  flutter_naver_map: d9f447f1271059759d4d5e38c3b347d7ab2ba835
+  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
+  geocoding_ios: 33776c9ebb98d037b5e025bb0e7537f6dd19646e
+  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   Google-Mobile-Ads-SDK: 4534fd2dfcd3f705c5485a6633c5188d03d4eed2
-  google_mobile_ads: 2ba32ffef4a026aa94f526774a40a14ca9662adf
-  google_sign_in_ios: 7336a3372ea93ea56a21e126a0055ffca3723601
+  google_mobile_ads: df3008bafbe1f2ad6862f87334e560d2f047f902
+  google_sign_in_ios: 000870aa06da9b28d1d0bf7ef70ff0213059dd28
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: fcee2257188d5eda57a5e2b6a715550ffff9206d
   GoogleUserMessagingPlatform: befe603da6501006420c206222acd449bba45a9c
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
-  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  kakao_flutter_sdk_common: a21740b9dd4900f96161f365a2b6ece7a97cbf4f
+  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
+  kakao_flutter_sdk_common: 682b3606698f87467788598dc2dc09d4e6867fbd
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   NMapsGeometry: 4e02554fa9880ef02ed96b075dc84355d6352479
   NMapsMap: 1964e6f9073301ad3cbe3a12235ba36f6f6cd905
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 0b743cbb62d8e47eab856f09262bb8c1ddcfe6ba
-  patrol: d49fcd015892f19189a4cec572f21f3c3358e761
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
+  patrol: cea8074f183a2a4232d0ebd10569ae05149ada42
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
-  sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
-  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
-  webview_flutter_wkwebview: 29eb20d43355b48fe7d07113835b9128f84e3af4
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
+  webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
 
 PODFILE CHECKSUM: ce2a4dd764e1c7aeed6a7cdc5e61d092b6dc6d32
 

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -8,6 +8,8 @@ import 'package:romrom_fe/screens/my_page_tab_screen.dart';
 import 'package:romrom_fe/screens/register_tab_screen.dart';
 import 'package:romrom_fe/screens/request_management_tab_screen.dart';
 import 'package:romrom_fe/services/heart_beat_manager.dart';
+import 'package:romrom_fe/services/app_review_service.dart';
+import 'package:romrom_fe/widgets/common/app_review_popup.dart';
 import 'package:romrom_fe/widgets/custom_bottom_navigation_bar.dart';
 
 /// 메인 화면
@@ -41,6 +43,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
       await _syncNotificationPermissionToBackend();
+      await AppReviewService().onAppLaunch();
     });
   }
 
@@ -125,19 +128,37 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     super.dispose();
   }
 
+  /// 앱 종료 시도 시 리뷰 팝업 조건 체크
+  Future<void> _onWillPop() async {
+    final service = AppReviewService();
+    if (await service.shouldShow(tradeTriggered: false)) {
+      if (mounted) {
+        await AppReviewPopup.show(context, service);
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      resizeToAvoidBottomInset: true,
-      extendBody: false,
-      body: IndexedStack(index: _currentTabIndex, children: _navigationTabScreens),
-      bottomNavigationBar: CustomBottomNavigationBar(
-        selectedIndex: _currentTabIndex,
-        onTap: (index) {
-          setState(() {
-            _currentTabIndex = index;
-          });
-        },
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
+        await _onWillPop();
+        if (mounted) Navigator.of(context).pop(result);
+      },
+      child: Scaffold(
+        resizeToAvoidBottomInset: true,
+        extendBody: false,
+        body: IndexedStack(index: _currentTabIndex, children: _navigationTabScreens),
+        bottomNavigationBar: CustomBottomNavigationBar(
+          selectedIndex: _currentTabIndex,
+          onTap: (index) {
+            setState(() {
+              _currentTabIndex = index;
+            });
+          },
+        ),
       ),
     );
   }

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -119,6 +119,15 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
       _syncNotificationPermissionToBackend();
+      _tryShowReviewPopup();
+    }
+  }
+
+  /// 앱 복귀 시 리뷰 팝업 조건 체크 (iOS/Android 공통)
+  Future<void> _tryShowReviewPopup() async {
+    final service = AppReviewService();
+    if (await service.shouldShow(tradeTriggered: false)) {
+      if (mounted) await AppReviewPopup.show(context, service);
     }
   }
 
@@ -128,37 +137,19 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
     super.dispose();
   }
 
-  /// 앱 종료 시도 시 리뷰 팝업 조건 체크
-  Future<void> _onWillPop() async {
-    final service = AppReviewService();
-    if (await service.shouldShow(tradeTriggered: false)) {
-      if (mounted) {
-        await AppReviewPopup.show(context, service);
-      }
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    return PopScope(
-      canPop: false,
-      onPopInvokedWithResult: (didPop, result) async {
-        if (didPop) return;
-        await _onWillPop();
-        if (mounted) Navigator.of(context).pop(result);
-      },
-      child: Scaffold(
-        resizeToAvoidBottomInset: true,
-        extendBody: false,
-        body: IndexedStack(index: _currentTabIndex, children: _navigationTabScreens),
-        bottomNavigationBar: CustomBottomNavigationBar(
-          selectedIndex: _currentTabIndex,
-          onTap: (index) {
-            setState(() {
-              _currentTabIndex = index;
-            });
-          },
-        ),
+    return Scaffold(
+      resizeToAvoidBottomInset: true,
+      extendBody: false,
+      body: IndexedStack(index: _currentTabIndex, children: _navigationTabScreens),
+      bottomNavigationBar: CustomBottomNavigationBar(
+        selectedIndex: _currentTabIndex,
+        onTap: (index) {
+          setState(() {
+            _currentTabIndex = index;
+          });
+        },
       ),
     );
   }

--- a/lib/screens/trade_review_screen.dart
+++ b/lib/screens/trade_review_screen.dart
@@ -11,6 +11,8 @@ import 'package:romrom_fe/screens/main_screen.dart';
 import 'package:romrom_fe/services/apis/trade_api.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/utils/error_utils.dart';
+import 'package:romrom_fe/services/app_review_service.dart';
+import 'package:romrom_fe/widgets/common/app_review_popup.dart';
 import 'package:romrom_fe/widgets/common/common_modal.dart';
 import 'package:romrom_fe/widgets/common/completion_button.dart';
 import 'package:romrom_fe/widgets/trade/rating_option_button.dart';
@@ -55,6 +57,18 @@ class _TradeReviewScreenState extends State<TradeReviewScreen> {
               : _commentController.text.trim(),
         ),
       );
+      if (!mounted) return;
+
+      // 거래 완료 횟수 기록 및 리뷰 팝업 조건 체크
+      final reviewService = AppReviewService();
+      await reviewService.onTradeComplete();
+
+      if (!mounted) return;
+
+      if (await reviewService.shouldShow(tradeTriggered: true)) {
+        if (mounted) await AppReviewPopup.show(context, reviewService);
+      }
+
       if (!mounted) return;
       context.navigateTo(
         screen: const MainScreen(),

--- a/lib/services/app_review_service.dart
+++ b/lib/services/app_review_service.dart
@@ -1,0 +1,155 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:in_app_review/in_app_review.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// 앱 리뷰 팝업 상태 관리 및 트리거 판단 서비스
+/// SharedPreferences 기반 로컬 저장, 백엔드 연동 없음
+class AppReviewService {
+  static final AppReviewService _instance = AppReviewService._internal();
+  factory AppReviewService() => _instance;
+  AppReviewService._internal();
+
+  // SharedPreferences 키
+  static const String _kDisabled = 'review_disabled';
+  static const String _kLastShown = 'review_last_shown';
+  static const String _kShownCount = 'review_shown_count';
+  static const String _kLaunchCount = 'app_launch_count';
+  static const String _kFirstLaunchDate = 'app_first_launch_date';
+  static const String _kTradeCompleteCount = 'trade_complete_count';
+
+  static const Duration _kCooldown = Duration(days: 14);
+  static const int _kMaxShownCount = 3;
+  static const int _kMinLaunchCount = 2;
+  static const int _kMinUsageDays = 3;
+
+  static const String _kIosStoreUrl = 'https://apps.apple.com/app/id6748823976';
+  static const String _kAndroidStoreUrl = 'https://play.google.com/store/apps/details?id=com.alom.romrom';
+
+  /// 앱 실행 시 호출 — 실행 횟수 +1, 첫 실행일 기록
+  Future<void> onAppLaunch() async {
+    final prefs = await SharedPreferences.getInstance();
+
+    // 첫 실행일 기록 (한 번만)
+    if (!prefs.containsKey(_kFirstLaunchDate)) {
+      await prefs.setInt(_kFirstLaunchDate, DateTime.now().millisecondsSinceEpoch);
+    }
+
+    final count = prefs.getInt(_kLaunchCount) ?? 0;
+    await prefs.setInt(_kLaunchCount, count + 1);
+    debugPrint('[AppReview] 앱 실행 횟수: ${count + 1}');
+  }
+
+  /// 거래 완료 시 호출 — 거래 완료 횟수 +1
+  Future<void> onTradeComplete() async {
+    final prefs = await SharedPreferences.getInstance();
+    final count = prefs.getInt(_kTradeCompleteCount) ?? 0;
+    await prefs.setInt(_kTradeCompleteCount, count + 1);
+    debugPrint('[AppReview] 거래 완료 횟수: ${count + 1}');
+  }
+
+  /// 팝업 표시 여부 판단
+  /// 거래 완료 트리거: tradeTriggered = true
+  /// 종료 트리거: tradeTriggered = false
+  Future<bool> shouldShow({bool tradeTriggered = false}) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    // 영구 비활성
+    if (prefs.getBool(_kDisabled) ?? false) {
+      debugPrint('[AppReview] 영구 비활성 → 표시 안 함');
+      return false;
+    }
+
+    // 노출 횟수 초과 → 영구 비활성 처리
+    final shownCount = prefs.getInt(_kShownCount) ?? 0;
+    if (shownCount >= _kMaxShownCount) {
+      await prefs.setBool(_kDisabled, true);
+      debugPrint('[AppReview] 노출 3회 초과 → 영구 비활성');
+      return false;
+    }
+
+    // 쿨타임 체크
+    final lastShownMs = prefs.getInt(_kLastShown);
+    if (lastShownMs != null) {
+      final lastShown = DateTime.fromMillisecondsSinceEpoch(lastShownMs);
+      if (DateTime.now().difference(lastShown) <= _kCooldown) {
+        debugPrint('[AppReview] 쿨타임 미경과 → 표시 안 함');
+        return false;
+      }
+    }
+
+    if (tradeTriggered) {
+      // 거래 완료 트리거: 거래 1회 이상 + 앱 사용 3일 이상
+      final tradeCount = prefs.getInt(_kTradeCompleteCount) ?? 0;
+      final firstLaunchMs = prefs.getInt(_kFirstLaunchDate);
+      if (tradeCount < 1 || firstLaunchMs == null) return false;
+
+      final firstLaunch = DateTime.fromMillisecondsSinceEpoch(firstLaunchMs);
+      final usageDays = DateTime.now().difference(firstLaunch).inDays;
+      final ok = usageDays >= _kMinUsageDays;
+      debugPrint('[AppReview] 거래 트리거: 거래=$tradeCount, 사용일수=$usageDays → ${ok ? '표시' : '미충족'}');
+      return ok;
+    } else {
+      // 종료 트리거: 앱 실행 2회 이상
+      final launchCount = prefs.getInt(_kLaunchCount) ?? 0;
+      final ok = launchCount >= _kMinLaunchCount;
+      debugPrint('[AppReview] 종료 트리거: 실행=$launchCount → ${ok ? '표시' : '미충족'}');
+      return ok;
+    }
+  }
+
+  /// 팝업 노출 기록
+  Future<void> markShown() async {
+    final prefs = await SharedPreferences.getInstance();
+    final count = prefs.getInt(_kShownCount) ?? 0;
+    await prefs.setInt(_kShownCount, count + 1);
+    await prefs.setInt(_kLastShown, DateTime.now().millisecondsSinceEpoch);
+    debugPrint('[AppReview] 노출 기록: ${count + 1}회');
+  }
+
+  /// [리뷰 남기기] 클릭 시 — 영구 비활성 + 네이티브 리뷰 요청
+  Future<void> requestReviewAndDisable() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_kDisabled, true);
+    debugPrint('[AppReview] 영구 비활성 처리');
+
+    await _requestReview();
+  }
+
+  /// in_app_review 호출, 실패 시 스토어 링크 폴백
+  Future<void> _requestReview() async {
+    final inAppReview = InAppReview.instance;
+    try {
+      if (await inAppReview.isAvailable()) {
+        await inAppReview.requestReview();
+        debugPrint('[AppReview] 네이티브 리뷰 다이얼로그 호출 성공');
+        return;
+      }
+    } catch (e) {
+      debugPrint('[AppReview] 네이티브 리뷰 실패: $e');
+    }
+    // 폴백: 스토어 링크 열기
+    await _openStoreLink();
+  }
+
+  Future<void> _openStoreLink() async {
+    final url = Uri.parse(Platform.isIOS ? _kIosStoreUrl : _kAndroidStoreUrl);
+    try {
+      if (await canLaunchUrl(url)) {
+        await launchUrl(url, mode: LaunchMode.externalApplication);
+        debugPrint('[AppReview] 스토어 링크 열기 성공');
+      }
+    } catch (e) {
+      debugPrint('[AppReview] 스토어 링크 열기 실패: $e');
+    }
+  }
+
+  /// [별로예요] / [나중에] / 닫기 — 14일 쿨타임만 기록
+  Future<void> markDismissed() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_kLastShown, DateTime.now().millisecondsSinceEpoch);
+    debugPrint('[AppReview] 닫기 기록 (14일 쿨타임)');
+  }
+}

--- a/lib/services/app_review_service.dart
+++ b/lib/services/app_review_service.dart
@@ -145,11 +145,4 @@ class AppReviewService {
       debugPrint('[AppReview] 스토어 링크 열기 실패: $e');
     }
   }
-
-  /// [별로예요] / [나중에] / 닫기 — 14일 쿨타임만 기록
-  Future<void> markDismissed() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_kLastShown, DateTime.now().millisecondsSinceEpoch);
-    debugPrint('[AppReview] 닫기 기록 (14일 쿨타임)');
-  }
 }

--- a/lib/widgets/common/app_review_popup.dart
+++ b/lib/widgets/common/app_review_popup.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:romrom_fe/services/app_review_service.dart';
+import 'package:romrom_fe/widgets/common/common_modal.dart';
+
+/// 앱 리뷰 유도 2단계 팝업 시퀀스
+/// Step 1: "잘 이용하고 계신가요?" 감성 질문
+/// Step 2: [좋아요] 선택 시 → "스토어 리뷰 남겨주실래요?"
+class AppReviewPopup {
+  /// 팝업 시퀀스 실행
+  /// context가 mounted 상태인지 호출 전 반드시 확인할 것
+  static Future<void> show(BuildContext context, AppReviewService service) async {
+    // 노출 기록 (Step 1이 뜨는 시점)
+    await service.markShown();
+
+    if (!context.mounted) return;
+
+    // Step 1: 감성 질문 팝업
+    final isPositive = await _showStep1(context);
+
+    if (!isPositive) return;
+
+    if (!context.mounted) return;
+
+    // Step 2: 리뷰 유도 팝업
+    final wantsReview = await _showStep2(context);
+
+    if (wantsReview) {
+      await service.requestReviewAndDisable();
+    }
+  }
+
+  /// Step 1: "RomRom을 잘 이용하고 계신가요?"
+  /// 반환값: true = [좋아요!], false = [별로예요] or 닫기
+  static Future<bool> _showStep1(BuildContext context) async {
+    final result = await CommonModal.confirm(
+      context: context,
+      message: 'RomRom을 잘 이용하고 계신가요?\n소중한 의견이 앱 개선에 도움이 됩니다 😊',
+      cancelText: '별로예요',
+      confirmText: '좋아요!',
+      onCancel: () => Navigator.of(context).pop(false),
+      onConfirm: () => Navigator.of(context).pop(true),
+    );
+    return result ?? false;
+  }
+
+  /// Step 2: "스토어 리뷰를 남겨주실래요?"
+  /// 반환값: true = [리뷰 남기기], false = [나중에] or 닫기
+  static Future<bool> _showStep2(BuildContext context) async {
+    final result = await CommonModal.confirm(
+      context: context,
+      message: '별점 한 줄이 큰 힘이 됩니다! ⭐\n스토어에 리뷰를 남겨주실래요?',
+      cancelText: '나중에',
+      confirmText: '리뷰 남기기',
+      onCancel: () => Navigator.of(context).pop(false),
+      onConfirm: () => Navigator.of(context).pop(true),
+    );
+    return result ?? false;
+  }
+}

--- a/lib/widgets/common/app_review_popup.dart
+++ b/lib/widgets/common/app_review_popup.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:romrom_fe/icons/app_icons.dart';
+import 'package:romrom_fe/models/app_colors.dart';
 import 'package:romrom_fe/services/app_review_service.dart';
 import 'package:romrom_fe/widgets/common/common_modal.dart';
 
@@ -37,6 +39,10 @@ class AppReviewPopup {
       message: 'RomRom을 잘 이용하고 계신가요?\n소중한 의견이 앱 개선에 도움이 됩니다 😊',
       cancelText: '별로예요',
       confirmText: '좋아요!',
+      icon: AppIcons.information,
+      iconColor: AppColors.primaryYellow,
+      confirmButtonColor: AppColors.primaryYellow,
+      confirmTextColor: AppColors.textColorBlack,
       onCancel: () => Navigator.of(context).pop(false),
       onConfirm: () => Navigator.of(context).pop(true),
     );
@@ -51,6 +57,10 @@ class AppReviewPopup {
       message: '별점 한 줄이 큰 힘이 됩니다! ⭐\n스토어에 리뷰를 남겨주실래요?',
       cancelText: '나중에',
       confirmText: '리뷰 남기기',
+      icon: AppIcons.information,
+      iconColor: AppColors.primaryYellow,
+      confirmButtonColor: AppColors.primaryYellow,
+      confirmTextColor: AppColors.textColorBlack,
       onCancel: () => Navigator.of(context).pop(false),
       onConfirm: () => Navigator.of(context).pop(true),
     );

--- a/lib/widgets/common/common_modal.dart
+++ b/lib/widgets/common/common_modal.dart
@@ -118,8 +118,9 @@ class CommonModal extends StatelessWidget {
     );
   }
 
-  /// 확인 모달 (빨간색 경고 아이콘, 2버튼)
+  /// 확인 모달 (2버튼)
   /// confirmText를 통해 '삭제', '나가기', '탈퇴' 등 커스텀 가능
+  /// icon/iconColor/confirmButtonColor 미지정 시 기본 경고(빨간색) 스타일 적용
   static Future<bool?> confirm({
     required BuildContext context,
     required String message,
@@ -127,7 +128,15 @@ class CommonModal extends StatelessWidget {
     String confirmText = '확인',
     required VoidCallback onCancel,
     required VoidCallback onConfirm,
+    IconData? icon,
+    Color? iconColor,
+    Color? confirmButtonColor,
+    Color? confirmTextColor,
   }) {
+    final resolvedIcon = icon ?? AppIcons.warning;
+    final resolvedIconColor = iconColor ?? AppColors.warningRed;
+    final resolvedConfirmButtonColor = confirmButtonColor ?? AppColors.warningRed;
+    final resolvedConfirmTextColor = confirmTextColor ?? AppColors.textColorWhite;
     return showGeneralDialog<bool>(
       context: context,
       barrierDismissible: false,
@@ -136,14 +145,14 @@ class CommonModal extends StatelessWidget {
       transitionDuration: AppMotion.slow,
       transitionBuilder: (context0, animation, secondaryAnimation0, child) => _buildTransition(child, animation),
       pageBuilder: (context0, animation0, secondaryAnimation0) => CommonModal._(
-        icon: AppIcons.warning,
-        iconColor: AppColors.warningRed,
-        iconBackgroundColor: AppColors.warningRed.withValues(alpha: 0.2),
+        icon: resolvedIcon,
+        iconColor: resolvedIconColor,
+        iconBackgroundColor: resolvedIconColor.withValues(alpha: 0.2),
         message: message,
         cancelText: cancelText,
         confirmText: confirmText,
-        confirmButtonColor: AppColors.warningRed,
-        confirmTextColor: AppColors.textColorWhite,
+        confirmButtonColor: resolvedConfirmButtonColor,
+        confirmTextColor: resolvedConfirmTextColor,
         onCancel: onCancel,
         onConfirm: onConfirm,
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -930,6 +930,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  in_app_review:
+    dependency: "direct main"
+    description:
+      name: in_app_review
+      sha256: "364db0c160b37fe7fad9cdaa18f968473924b17368869010af902760421b6bf8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.12"
+  in_app_review_platform_interface:
+    dependency: transitive
+    description:
+      name: in_app_review_platform_interface
+      sha256: fed2c755f2125caa9ae10495a3c163aa7fab5af3585a9c62ef4a6920c5b45f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   integration_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   gradient_borders: ^1.0.1
   http: ^1.3.0
   http_parser: ^4.0.2
+  in_app_review: ^2.0.9
   image_picker: ^1.1.2
   intl: ^0.20.2
   json_annotation: ^4.9.0


### PR DESCRIPTION
## 구현 내용

- `in_app_review` 패키지 추가 — iOS/Android 네이티브 리뷰 다이얼로그 호출
- `AppReviewService` 신규 — SharedPreferences 기반 상태 관리 (쿨타임 14일, 최대 3회, 영구 비활성)
- `AppReviewPopup` 신규 — 2단계 CommonModal 시퀀스 (프리스크린 → 리뷰 유도)
- 거래 완료 트리거 (`TradeReviewScreen`) + 앱 종료 트리거 (`MainScreen` PopScope) 연동

## 플로우

"RomRom을 잘 이용하고 계신가요?" → [좋아요!] → "스토어 리뷰를 남겨주실래요?" → [리뷰 남기기] → in_app_review 네이티브 다이얼로그 (실패 시 스토어 링크 폴백)

## 관련 이슈

- https://github.com/TEAM-ROMROM/RomRom-FE/issues/811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* 앱 리뷰 팝업 2단계 구현 계획 및 설계 문서 추가

## New Features
* 앱 리뷰 팝업 기능 구현 (2단계 유도 흐름)
* 앱 실행 및 거래 완료 후 팝업 자동 표시
* 표시 조건: 최대 3회 노출, 14일 쿨타임, 거래 완료 시 3일 이상 앱 사용 필요
* 네이티브 리뷰 요청 및 스토어 링크 폴백 지원

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-ROMROM/RomRom-FE/pull/861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->