### PR TITLE
교환 완료 요청 전송 후 요청자 화면에 요청 상태 미표시 : feat : 거래 요청 시 낙관적 로컬 메시지 삽입, 웹소켓 도…

### DIFF
--- a/docs/suh-template/analyze/20260525_862_버그채팅_교환요청_전송_후_요청자_화면에_요청_상태_미표시.md
+++ b/docs/suh-template/analyze/20260525_862_버그채팅_교환요청_전송_후_요청자_화면에_요청_상태_미표시.md
@@ -1,0 +1,265 @@
+# 분석: #862 버그 - 교환 완료 요청 전송 후 요청자 화면에 요청 상태 미표시
+
+> 생성일: 2026-05-25  
+> 연관 이슈: [#862](https://github.com/TEAM-ROMROM/RomRom-FE/issues/862)
+
+---
+
+## 📊 분석 요약
+
+| 항목 | 내용 |
+|------|------|
+| **프로젝트 타입** | Flutter (iOS/Android) |
+| **기술 스택** | Flutter, STOMP WebSocket (`stomp_dart_client`), REST API |
+| **영향 범위** | 채팅 교환 완료 요청 흐름 전체 |
+| **심각도** | 높음 — 요청자가 취소 버튼을 볼 수 없어 요청 철회 불가 |
+
+---
+
+## 🔍 현재 상태 (코드베이스 흐름)
+
+### 교환 완료 요청 전송 흐름
+
+```
+[요청자]
+  _onRequestExchange()                                   ← 버튼 탭
+    → ExchangeRequestBottomSheet.show()                  ← 바텀시트 표시
+      → onConfirm: _doRequestTradeCompletion()           ← 확인 버튼
+          → ChatApi().requestTradeCompletion()           ← REST API 호출
+          → .then((_) { /* "WebSocket 브로드캐스트 대기 중..." */ })
+                                ↕ (WebSocket 이벤트 대기)
+  _messageSubscription.listen(_handleIncomingMessage)   ← WS 수신 시 처리
+    → _messages.insert(0, newMessage)
+    → setState() → itemBuilder → _buildTradeRequestCard()
+```
+
+### 핵심 관련 파일
+
+| 파일 | 관련 메서드 |
+|------|------------|
+| `lib/screens/chat_room_screen.dart:631` | `_doRequestTradeCompletion()` |
+| `lib/screens/chat_room_screen.dart:368` | `_handleIncomingMessage()` |
+| `lib/screens/chat_room_screen.dart:702` | `_isActiveTradeRequest()` |
+| `lib/screens/chat_room_screen.dart:860` | `itemBuilder` 콜백 |
+| `lib/widgets/chat_message_item.dart:64` | `_buildTradeSystemMessage()` |
+| `lib/widgets/chat_message_item.dart:79` | `hasButtons` 조건 분기 |
+
+---
+
+## 🎯 근본 원인 분석
+
+### 🔴 ROOT CAUSE 1 (주요): WebSocket 브로드캐스트가 요청자에게 미전달
+
+**위치**: `lib/screens/chat_room_screen.dart:631-648`
+
+```dart
+void _doRequestTradeCompletion() {
+  // ...
+  ChatApi()
+      .requestTradeCompletion(chatRoomId: widget.chatRoomId)
+      .then((_) {
+        debugPrint('[ChatRoom] 교환 완료 요청 API 성공 → 이후 WebSocket 브로드캐스트 대기 중...');
+        // ⚠️ UI 업데이트 없음. 순수하게 WebSocket만 기다림
+        if (mounted) setState(() => _isPendingTradeAction = false);
+      })
+```
+
+**문제**: `_doRequestTradeCompletion()`은 REST API 성공 후 **100% WebSocket 브로드캐스트에만 의존**하여 요청 카드를 표시한다.
+
+그러나 백엔드의 `TRADE_COMPLETE_REQUEST` WebSocket 이벤트가 **요청자(보낸 사람)에게는 발송되지 않고 수신자(상대방)에게만 발송**되는 것으로 추정된다.
+
+| 역할 | WebSocket 수신 | 화면 표시 |
+|------|----------------|-----------|
+| 수신자 (상대방) | ✅ `TRADE_COMPLETE_REQUEST` 수신 | ✅ "거절하기/확인 및 완료하기" 카드 정상 표시 |
+| 요청자 (본인) | ❌ 이벤트 미수신 | ❌ `_messages` 업데이트 없음 → 카드 미표시 |
+
+이슈에서 "상대방 화면에는 정상 표시됨"이 명시된 것이 결정적 증거다.
+
+---
+
+### 🟠 ROOT CAUSE 2 (보조): 낙관적 UI 업데이트(Optimistic Update) 부재
+
+**위치**: `lib/screens/chat_room_screen.dart:449-476`  
+**비교 대상**: `_sendImage()` — 이미지 메시지 전송 시 낙관적 업데이트 사용
+
+```dart
+// ✅ 이미지 전송: 낙관적 업데이트 있음
+Future<void> _sendImage({...}) async {
+  final localMsg = ChatMessage(/* 로컬 임시 메시지 */);
+  setState(() {
+    _messages.insert(0, localMsg);            // ← 즉시 화면에 표시
+    _pendingLocalMessages[localId] = localMsg; // ← 서버 에코 시 교체 추적
+  });
+  _wsService.sendMessage(...); // WebSocket 전송
+}
+
+// ❌ 교환 완료 요청: 낙관적 업데이트 없음
+void _doRequestTradeCompletion() {
+  ChatApi().requestTradeCompletion(...).then((_) {
+    // _messages.insert(0, ...) ← 이런 코드가 없음
+    // WebSocket 브로드캐스트만 기다림
+  });
+}
+```
+
+---
+
+### 🟡 "이미 처리된 요청입니다" 표시 케이스 별도 분석
+
+**위치**: `lib/widgets/chat_message_item.dart:79-87`
+
+```dart
+final hasButtons = isMine ? onCancelTradeRequest != null : onRejectTradeRequest != null;
+
+if (hasButtons) {
+  return _buildTradeRequestCard(isMine: isMine);
+}
+
+// 비활성(이미 처리된) 요청 - 심플 텍스트
+final inactiveText = isMine ? '교환 완료를 요청했습니다.' : '...';
+return _buildSimpleCard(inactiveText, '이미 처리된 요청입니다.');  // ← 여기 도달
+```
+
+`onCancelTradeRequest`가 null이 되는 조건: `_isActiveTradeRequest(index) == false`
+
+`_isActiveTradeRequest` 로직 (`chat_room_screen.dart:702-713`):
+```dart
+bool _isActiveTradeRequest(int index) {
+  if (_isTradeCompleted) return false;  // ← 이미 완료된 거래면 false
+  for (int i = 0; i < index; i++) {    // ← 더 최신 메시지 중 취소/거절/완료 있으면 false
+    final t = _messages[i].type;
+    if (t == MessageType.tradeCompleteRequestCanceled ||
+        t == MessageType.tradeCompleteRequestRejected ||
+        t == MessageType.tradeCompleted) {
+      return false;
+    }
+  }
+  return true;
+}
+```
+
+`_isTradeCompleted` 조건:
+```dart
+bool get _isTradeCompleted =>
+    chatRoom.tradeRequestHistory?.tradeStatus == TradeStatus.traded.serverName /* 'TRADED' */ ||
+    _messages.any((m) => m.type == MessageType.tradeCompleted);
+```
+
+**발생 시나리오**:
+1. 이전에 교환이 완료된(`TRADED`) 채팅방을 다시 열 때 → `tradeStatus == 'TRADED'` → 히스토리 메시지에 "이미 처리된 요청입니다" 표시 (정상 동작)
+2. WebSocket이 요청자에게 메시지를 전달하긴 하는데 **지연**되는 경우 — 페이지 재진입 시 REST API 히스토리에 요청 메시지가 이미 있고, 동시에 더 최신의 취소/거절 메시지가 있는 케이스
+
+---
+
+## 📝 상세 구현 계획
+
+### Phase 1 — Frontend 수정 (핵심, 독립적 해결)
+
+**`_doRequestTradeCompletion()` 수정** — 낙관적 업데이트 패턴 추가
+
+REST API 성공 시 로컬 메시지를 즉시 삽입하고, 이후 WebSocket 에코가 오면 교체한다.
+
+```dart
+// chat_room_screen.dart
+const _localTradeRequestId = 'local_trade_request';
+
+void _doRequestTradeCompletion() {
+  if (_isPendingTradeAction) return;
+  setState(() => _isPendingTradeAction = true);
+
+  ChatApi()
+      .requestTradeCompletion(chatRoomId: widget.chatRoomId)
+      .then((_) {
+        if (!mounted) return;
+        setState(() {
+          _isPendingTradeAction = false;
+          // 낙관적 업데이트: WebSocket 미수신에 대비
+          // (WebSocket에서 실제 메시지가 오면 _handleIncomingMessage에서 교체)
+          final alreadyReceived = _messages.any(
+            (m) => m.type == MessageType.tradeCompleteRequest &&
+                   m.senderId == _myMemberId &&
+                   m.chatMessageId != _localTradeRequestId,
+          );
+          if (!alreadyReceived) {
+            _messages.insert(
+              0,
+              ChatMessage(
+                chatRoomId: widget.chatRoomId,
+                chatMessageId: _localTradeRequestId,
+                senderId: _myMemberId,
+                createdDate: DateTime.now(),
+                type: MessageType.tradeCompleteRequest,
+              ),
+            );
+          }
+        });
+      })
+      .catchError((e) { /* 기존 에러 처리 유지 */ });
+}
+```
+
+**`_handleIncomingMessage()` 수정** — WebSocket 도착 시 로컬 메시지 교체
+
+```dart
+void _handleIncomingMessage(ChatMessage newMessage) {
+  // ... 기존 중복 체크 ...
+
+  // 교환 완료 요청 메시지가 WebSocket으로 도착하면 로컬 임시 메시지 제거
+  if (newMessage.type == MessageType.tradeCompleteRequest &&
+      newMessage.senderId == _myMemberId) {
+    _messages.removeWhere((m) => m.chatMessageId == _localTradeRequestId);
+  }
+
+  // ... 기존 로직 계속 ...
+}
+```
+
+### Phase 2 — 백엔드 협업 (권장, 근본적 해결)
+
+백엔드에서 `TRADE_COMPLETE_REQUEST` WebSocket 이벤트를 **요청자에게도 브로드캐스트**하도록 수정 요청.  
+이렇게 되면 Frontend는 낙관적 업데이트 없이도 동작하지만, 낙관적 업데이트는 네트워크 지연 대비용으로 유지하는 것이 좋다.
+
+---
+
+## ⚠️ 주의사항 및 부가 발견 사항
+
+### 1. `chatRoom.tradeRequestHistory` 미갱신 문제
+
+`requestTradeCompletion` API 성공 후 `chatRoom` 객체가 업데이트되지 않는다.  
+만약 API 응답에 새 `tradeRequestHistoryId`가 포함된다면, 이후 `TradeReviewScreen` 진입 시 stale 값이 사용될 수 있다.
+
+```dart
+// chat_room_screen.dart:684
+final tradeRequestHistoryId = chatRoom.tradeRequestHistory?.tradeRequestHistoryId;
+// ↑ requestTradeCompletion 이후 갱신되지 않음
+```
+
+현재는 채팅방 진입 시 최초 로드된 `tradeRequestHistoryId`를 계속 사용한다. 백엔드 명세 확인 필요.
+
+### 2. 로컬 임시 메시지의 `key` 고려
+
+`itemBuilder`에서 `key: ValueKey(message.chatMessageId ?? ...)` 사용.  
+로컬 임시 메시지의 `chatMessageId = _localTradeRequestId` (고정 문자열)이므로,  
+WebSocket 메시지로 교체 시 Flutter가 위젯을 올바르게 재빌드하는지 확인 필요.  
+`setState(() { remove + insert })` 패턴이므로 정상 동작 예상.
+
+### 3. 취소 불가 UX 문제
+
+요청 카드가 미표시되면 "요청 취소하기" 버튼도 보이지 않아 요청자가 요청을 취소할 수 없다.  
+낙관적 업데이트 추가 시 이 문제도 동시 해결된다.
+
+---
+
+## 📁 변경 필요 파일
+
+| 파일 | 변경 내용 | 우선순위 |
+|------|----------|---------|
+| `lib/screens/chat_room_screen.dart` | `_doRequestTradeCompletion()` 낙관적 업데이트 추가 | 🔴 필수 |
+| `lib/screens/chat_room_screen.dart` | `_handleIncomingMessage()` 로컬 메시지 교체 로직 추가 | 🔴 필수 |
+| (백엔드) trade-completion REST handler | `TRADE_COMPLETE_REQUEST` WS 이벤트를 요청자에게도 전송 | 🟠 권장 |
+
+---
+
+## 다음 단계
+
+→ `/implement`로 구현 진행

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,6 @@ import 'package:romrom_fe/models/app_theme.dart';
 import 'package:romrom_fe/screens/app_update_screen.dart';
 import 'package:romrom_fe/screens/splash_screen.dart';
 import 'package:romrom_fe/services/apis/app_version_api.dart';
-import 'package:romrom_fe/services/apis/notification_api.dart';
 import 'package:romrom_fe/services/app_initializer.dart';
 import 'package:romrom_fe/services/android_navigation_mode.dart';
 import 'package:romrom_fe/services/firebase_service.dart';
@@ -63,9 +62,6 @@ void main() async {
   // 알림 권한 요청 설정
   await FirebaseService().setupPushNotifications();
 
-  // FCM 토큰 갱신 감지 및 자동 저장 설정
-  _setupFcmTokenRefreshListener();
-
   // 시스템 오버레이 색상 설정
   SystemChrome.setSystemUIOverlayStyle(
     const SystemUiOverlayStyle(systemNavigationBarColor: AppColors.primaryBlack, statusBarColor: Colors.transparent),
@@ -82,14 +78,6 @@ void main() async {
   }
 
   runApp(ProviderScope(child: MyApp(isGestureMode: isGestureMode)));
-}
-
-/// FCM 토큰 갱신 감지 및 자동 저장 설정
-void _setupFcmTokenRefreshListener() {
-  final firebaseService = FirebaseService();
-  final notificationApi = NotificationApi();
-
-  firebaseService.setupTokenRefreshListener(notificationApi);
 }
 
 /// 앱의 루트 위젯

--- a/lib/screens/chat_room_screen.dart
+++ b/lib/screens/chat_room_screen.dart
@@ -56,6 +56,9 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> with WidgetsBindingObse
   List<ChatMessage> _messages = [];
   StreamSubscription<ChatMessage>? _messageSubscription;
 
+  // 교환 완료 요청 낙관적 업데이트용 로컬 임시 메시지 ID
+  static const _localTradeRequestId = 'local_trade_request_optimistic';
+
   // 낙관적 로컬 메시지(서버 응답 대기)
   final Map<String, ChatMessage> _pendingLocalMessages = {};
 
@@ -415,6 +418,12 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> with WidgetsBindingObse
         _messages.insert(0, fixedServer);
       }
     } else {
+      // 교환 완료 요청 WS 에코 도착: 낙관적 로컬 메시지를 실제 서버 메시지로 교체
+      if (newMessage.type == MessageType.tradeCompleteRequest && newMessage.senderId == _myMemberId) {
+        _messages.removeWhere((m) => m.chatMessageId == _localTradeRequestId);
+        debugPrint('[ChatRoom] 교환 완료 요청 WS 에코 수신 → 로컬 임시 메시지 교체');
+      }
+
       // WebSocket 브로드캐스트에 imageUrls 미포함 시 REST API로 보완
       if (newMessage.type == MessageType.image && (newMessage.imageUrls == null || newMessage.imageUrls!.isEmpty)) {
         final tempId = 'ws_img_${DateTime.now().microsecondsSinceEpoch}';
@@ -635,8 +644,32 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> with WidgetsBindingObse
     ChatApi()
         .requestTradeCompletion(chatRoomId: widget.chatRoomId)
         .then((_) {
-          debugPrint('[ChatRoom] 교환 완료 요청 API 성공 → 이후 WebSocket 브로드캐스트 대기 중...');
-          if (mounted) setState(() => _isPendingTradeAction = false);
+          debugPrint('[ChatRoom] 교환 완료 요청 API 성공');
+          if (!mounted) return;
+          setState(() {
+            _isPendingTradeAction = false;
+            // 낙관적 업데이트: 백엔드 WS 브로드캐스트가 요청자에게 도달하지 않는 경우를 대비해
+            // REST API 성공 즉시 로컬 메시지를 삽입해 요청 카드를 표시한다.
+            // WS 에코가 나중에 도착하면 _handleIncomingMessage에서 이 로컬 메시지를 교체한다.
+            final alreadyReceived = _messages.any(
+              (m) =>
+                  m.type == MessageType.tradeCompleteRequest &&
+                  m.senderId == _myMemberId &&
+                  m.chatMessageId != _localTradeRequestId,
+            );
+            if (!alreadyReceived) {
+              _messages.insert(
+                0,
+                ChatMessage(
+                  chatRoomId: widget.chatRoomId,
+                  chatMessageId: _localTradeRequestId,
+                  senderId: _myMemberId,
+                  createdDate: DateTime.now(),
+                  type: MessageType.tradeCompleteRequest,
+                ),
+              );
+            }
+          });
         })
         .catchError((e) {
           debugPrint('[ChatRoom] 교환 완료 요청 API 실패: $e');

--- a/lib/screens/chat_room_screen.dart
+++ b/lib/screens/chat_room_screen.dart
@@ -57,7 +57,7 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> with WidgetsBindingObse
   StreamSubscription<ChatMessage>? _messageSubscription;
 
   // 교환 완료 요청 낙관적 업데이트용 로컬 임시 메시지 ID
-  static const _localTradeRequestId = 'local_trade_request_optimistic';
+  String? _latestLocalTradeRequestId;
 
   // 낙관적 로컬 메시지(서버 응답 대기)
   final Map<String, ChatMessage> _pendingLocalMessages = {};
@@ -420,8 +420,12 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> with WidgetsBindingObse
     } else {
       // 교환 완료 요청 WS 에코 도착: 낙관적 로컬 메시지를 실제 서버 메시지로 교체
       if (newMessage.type == MessageType.tradeCompleteRequest && newMessage.senderId == _myMemberId) {
-        _messages.removeWhere((m) => m.chatMessageId == _localTradeRequestId);
-        debugPrint('[ChatRoom] 교환 완료 요청 WS 에코 수신 → 로컬 임시 메시지 교체');
+        final localId = _latestLocalTradeRequestId;
+        if (localId != null) {
+          _messages.removeWhere((m) => m.chatMessageId == localId);
+          _latestLocalTradeRequestId = null;
+          debugPrint('[ChatRoom] 교환 완료 요청 WS 에코 수신 → 로컬 임시 메시지 교체');
+        }
       }
 
       // WebSocket 브로드캐스트에 imageUrls 미포함 시 REST API로 보완
@@ -546,11 +550,13 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> with WidgetsBindingObse
 
       final localId = 'uploading_${DateTime.now().microsecondsSinceEpoch}';
       setState(() {
+        final localTradeRequestId = 'local_trade_request_${DateTime.now().microsecondsSinceEpoch}';
+        _latestLocalTradeRequestId = localTradeRequestId;
         _messages.insert(
           0,
           ChatMessage(
             chatRoomId: widget.chatRoomId,
-            chatMessageId: localId,
+            chatMessageId: localTradeRequestId,
             senderId: _myMemberId,
             createdDate: DateTime.now(),
             content: '사진을 보냈습니다.',
@@ -651,18 +657,16 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> with WidgetsBindingObse
             // 낙관적 업데이트: 백엔드 WS 브로드캐스트가 요청자에게 도달하지 않는 경우를 대비해
             // REST API 성공 즉시 로컬 메시지를 삽입해 요청 카드를 표시한다.
             // WS 에코가 나중에 도착하면 _handleIncomingMessage에서 이 로컬 메시지를 교체한다.
-            final alreadyReceived = _messages.any(
-              (m) =>
-                  m.type == MessageType.tradeCompleteRequest &&
-                  m.senderId == _myMemberId &&
-                  m.chatMessageId != _localTradeRequestId,
+            final latestMyRequestIndex = _messages.indexWhere(
+              (m) => m.type == MessageType.tradeCompleteRequest && m.senderId == _myMemberId,
             );
+            final alreadyReceived = latestMyRequestIndex != -1 && _isActiveTradeRequest(latestMyRequestIndex);
             if (!alreadyReceived) {
               _messages.insert(
                 0,
                 ChatMessage(
                   chatRoomId: widget.chatRoomId,
-                  chatMessageId: _localTradeRequestId,
+                  chatMessageId: _latestLocalTradeRequestId,
                   senderId: _myMemberId,
                   createdDate: DateTime.now(),
                   type: MessageType.tradeCompleteRequest,

--- a/lib/services/firebase_service.dart
+++ b/lib/services/firebase_service.dart
@@ -8,9 +8,15 @@ import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/models/app_colors.dart';
 import 'package:romrom_fe/services/local_notification_service.dart';
 import 'package:romrom_fe/services/apis/notification_api.dart';
+import 'package:romrom_fe/services/token_manager.dart';
 import 'package:romrom_fe/utils/deep_link_router.dart';
 
 class FirebaseService {
+  // 싱글톤 구현
+  static final FirebaseService _instance = FirebaseService._internal();
+  factory FirebaseService() => _instance;
+  FirebaseService._internal();
+
   // Foreground 메시지를 UI에서 구독할 수 있도록 브로드캐스트 스트림 제공
   final StreamController<RemoteMessage> _foregroundMessageController = StreamController<RemoteMessage>.broadcast();
 
@@ -161,6 +167,7 @@ class FirebaseService {
   }
 
   /// FCM 토큰 갱신 감지 및 자동 저장
+  /// 콜백 실행 시점에 인증 토큰 유무를 확인하여 미인증 상태에서의 silent fail 방지
   void setupTokenRefreshListener(NotificationApi notificationApi) {
     if (_tokenRefreshListenerSet) return;
 
@@ -170,8 +177,15 @@ class FirebaseService {
     onTokenRefresh(
       onTokenRefreshed: (String newToken) async {
         try {
+          // 인증 전 토큰 갱신 이벤트 도달 시 저장 스킵
+          // (로그인/온보딩 완료 후 handleFcmToken()이 최신 토큰을 다시 저장함)
+          final accessToken = await TokenManager().getAccessToken();
+          if (accessToken == null) {
+            debugPrint('[FCM] 인증 전 토큰 갱신 감지 → 저장 스킵');
+            return;
+          }
           await notificationApi.saveFcmToken(fcmToken: newToken);
-          debugPrint('[FCM] 갱신된 FCM 토큰 저장 완료: $newToken');
+          debugPrint('[FCM] 갱신된 FCM 토큰 저장 완료');
         } catch (e) {
           debugPrint('[FCM] 갱신된 FCM 토큰 저장 실패: $e');
         }


### PR DESCRIPTION
#862 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 채팅 화면에서 교환 완료 요청 전송 후 요청 상태가 즉시 표시되지 않던 문제를 해결했습니다. 로컬 메시지 처리 로직을 개선하여 더 빠르고 안정적인 상태 업데이트를 제공합니다.

* **Documentation**
  * 채팅 교환 요청 관련 버그 분석 문서를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-ROMROM/RomRom-FE/pull/864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->