### PR TITLE
20260525 #865 백엔드 서버 무응답 시 스플래시 화면 무한 로딩

### DIFF
--- a/docs/suh-template/analyze/20260525_865_버그_스플래시_화면_백엔드_무응답_시_무한로딩.md
+++ b/docs/suh-template/analyze/20260525_865_버그_스플래시_화면_백엔드_무응답_시_무한로딩.md
@@ -1,0 +1,214 @@
+# 분석 보고서: 스플래시 화면 백엔드 무응답 시 무한 로딩
+
+> 이슈: [#865 ❗[버그][스플래시] 백엔드 서버 무응답 시 스플래시 화면 무한 로딩](https://github.com/TEAM-ROMROM/RomRom-FE/issues/865)  
+> 날짜: 2026-05-25  
+> 담당자: @SeoHyun1024
+
+---
+
+## 📊 분석 요약
+
+| 항목 | 내용 |
+|------|------|
+| **프로젝트 타입** | Flutter (iOS/Android) |
+| **주요 기술 스택** | Flutter, Dart, `package:http` |
+| **코드 스타일** | 싱글톤 패턴, ApiClient 중앙화, `Future.wait` 병렬 처리 |
+| **버그 심각도** | 🔴 높음 — 서버 장애 시 앱이 스플래시에 영구 대기, UX 완전 차단 |
+
+---
+
+## 🔍 현재 상태
+
+### 스플래시 화면 흐름 (`lib/screens/splash_screen.dart`)
+
+```
+initState()
+  └── _initAndNavigate() [unawaited]
+        ├── 1. AppVersionApi().checkUpdateType()  ← timeout 없음
+        ├── 2. Future.wait([
+        │       _determineInitialScreen(),         ← 내부에 timeout 없는 API 다수
+        │       Future.delayed(2초)
+        │   ])
+        └── 3. 화면 전환
+```
+
+### 문제 지점별 분석
+
+#### 1. `AppVersionApi.checkUpdateType()` (`lib/services/apis/app_version_api.dart`)
+- `LoggingHttpClient(http.Client())` 사용 → **timeout 미설정**
+- `_client.post(Uri.parse(url), ...)` 직접 호출 → 응답 없으면 무한 대기
+- 예외 catch 하지만 **SocketException, TimeoutException은 발생하지 않음** (연결 자체가 끊기지 않는 경우)
+
+#### 2. `RomAuthApi.refreshAccessToken()` (`lib/services/apis/rom_auth_api.dart`)
+- `ApiClient.sendMultipartRequest(...)` 사용
+- 내부적으로 `_client.send(request)` → **timeout 미설정**
+- 서버가 응답하지 않으면 `try-catch`까지 도달하지 못함
+
+#### 3. `UserInfo.getUserInfo()` (`lib/models/user_info.dart`)
+- `SharedPreferences` 기반 → 로컬 읽기만 수행 → **timeout 영향 없음**
+
+#### 4. `MemberManager.getCurrentMember()` (`lib/services/member_manager_service.dart`)
+- 캐시 없을 때 `MemberApi().getMemberInfo()` 호출 → `ApiClient` 사용 → **timeout 미설정**
+
+### `LoggingHttpClient`의 timeout 부재 확인 (`lib/utils/log_http_client_interceptor.dart`)
+```dart
+@override
+Future<http.StreamedResponse> send(http.BaseRequest request) async {
+  // timeout 처리 없음
+  final streamedResponse = await _inner.send(request);  // ← 영구 대기 가능
+  ...
+}
+```
+
+---
+
+## 🎯 구현 목표
+
+1. **스플래시 전체 흐름에 타임아웃 10초 적용** — 10초 내 완료되지 않으면 로그인 화면 이동
+2. **개별 HTTP 요청에 타임아웃 설정** — `LoggingHttpClient` 또는 `ApiClient` 레벨에서 처리
+3. **네트워크 에러 시 사용자에게 SnackBar 안내** (선택적)
+
+---
+
+## 📝 상세 구현 계획
+
+### 1️⃣ 방법 A: 스플래시 전체에 `.timeout()` 적용 (가장 단순, 추천)
+
+**변경 대상**: `lib/screens/splash_screen.dart` — `_initAndNavigate()` 내부
+
+```dart
+Future<void> _initAndNavigate() async {
+  try {
+    await _runInitFlow().timeout(
+      const Duration(seconds: 10),
+      onTimeout: () {
+        debugPrint('[SplashScreen] 초기화 타임아웃 (10초) — 로그인 화면으로 이동');
+      },
+    );
+  } on TimeoutException {
+    if (!mounted) return;
+    await _playLoginTransitionAnimation();
+  } catch (e, st) {
+    debugPrint('[SplashScreen] 초기화 실패: $e\n$st');
+    if (!mounted) return;
+    await _playLoginTransitionAnimation();
+  }
+}
+
+Future<void> _runInitFlow() async {
+  final updateType = await AppVersionApi().checkUpdateType();
+  if (updateType == UpdateType.force && mounted) {
+    context.navigateTo(screen: const AppUpdateScreen(), type: NavigationTypes.fadeTransition);
+    return;
+  }
+
+  final results = await Future.wait([_determineInitialScreen(), Future.delayed(const Duration(seconds: 2))]);
+  // ... 기존 로직
+}
+```
+
+**장점**: 코드 변경 최소, 모든 하위 호출에 자동 적용  
+**단점**: 어느 API에서 느린지 로깅이 불명확
+
+---
+
+### 2️⃣ 방법 B: `LoggingHttpClient`에 글로벌 timeout 추가
+
+**변경 대상**: `lib/utils/log_http_client_interceptor.dart`
+
+```dart
+static const Duration _defaultTimeout = Duration(seconds: 10);
+
+@override
+Future<http.StreamedResponse> send(http.BaseRequest request) async {
+  // ...
+  final streamedResponse = await _inner.send(request).timeout(
+    _defaultTimeout,
+    onTimeout: () => throw TimeoutException('HTTP 타임아웃: ${request.url}', _defaultTimeout),
+  );
+  // ...
+}
+```
+
+**장점**: 모든 API 호출에 일괄 적용, 개별 API 수정 불필요  
+**단점**: 파일 업로드 등 장시간 작업에도 10초 제한이 걸릴 수 있음 (별도 처리 필요)
+
+---
+
+### 3️⃣ 권장 구현 — A + B 조합
+
+| 레이어 | 적용 방식 | 타임아웃 |
+|--------|-----------|----------|
+| `LoggingHttpClient` (방법 B) | 개별 HTTP 요청 타임아웃 | 10초 |
+| `SplashScreen._initAndNavigate()` (방법 A) | 스플래시 전체 흐름 타임아웃 | 15초 (여유) |
+
+이중 방어: 개별 API가 10초 → TimeoutException → `_initAndNavigate` catch → 로그인 화면  
+만약 TimeoutException이 누락되더라도 15초 전체 타임아웃이 최종 보장
+
+---
+
+### 4️⃣ 핵심 구현 파일별 변경 요약
+
+| 파일 | 변경 내용 | 변경 규모 |
+|------|-----------|-----------|
+| `lib/utils/log_http_client_interceptor.dart` | `send()` 메서드에 `.timeout()` 추가 | 소 (5줄 이내) |
+| `lib/screens/splash_screen.dart` | `_initAndNavigate()` 전체를 `.timeout()`으로 감싸기 + `TimeoutException` catch | 소 (10줄 이내) |
+
+---
+
+## 3️⃣ 테스트 시나리오
+
+| 시나리오 | 기대 결과 |
+|----------|-----------|
+| 서버 정상 | 기존 동작과 동일 (2초 + API 응답 시간 후 이동) |
+| 서버 완전 오프라인 (`Connection refused`) | `SocketException` → catch → 로그인 화면 이동 |
+| 서버 응답 없음 (hang) | 10초 후 `TimeoutException` → 로그인 화면 이동 |
+| 서버 느린 응답 (5초) | 정상 완료 (10초 이내이므로) |
+| 서버 느린 응답 (11초) | timeout → 로그인 화면 이동 |
+| 앱 버전 강제 업데이트 | timeout 이전에 정상 처리 (업데이트 화면 이동) |
+
+---
+
+## ⚠️ 주의사항
+
+### 위험 요소
+1. **파일 업로드 API**: `LoggingHttpClient` 전역 10초 timeout 적용 시, 이미지 업로드 등 장시간 작업 차단 가능
+   - **대응**: 파일 업로드 시 `timeout` 값을 늘리거나, `_executeMultipartRequest`에 별도 timeout 파라미터 추가
+   
+2. **`Future.wait` 내 `_determineInitialScreen()`**: 여러 API를 순차 호출 → 각 API 10초라면 최대 30~40초 가능
+   - **대응**: 스플래시 전체 `.timeout(15초)` 보조 적용 (방법 A)
+
+3. **기존 catch 블록**: `_initAndNavigate()`의 `catch (e, st)` 블록이 이미 있으므로 `TimeoutException`도 자동 catch → `_playLoginTransitionAnimation()` 호출됨
+   - 명시적으로 `on TimeoutException` 추가하면 더 명확한 로깅 가능
+
+### 사이드 이펙트
+- `AppVersionApi.checkUpdateType()` 내부 try-catch가 이미 있어, timeout exception은 외부로 전파됨 (정상)
+- `refreshAccessToken()`은 `catch (e)` 블록이 있어 timeout exception을 잡아 `false` 반환 → 로그인 화면 이동 (정상)
+
+### SnackBar 안내 (선택 구현)
+- 타임아웃 발생 시 `'서버 연결이 원활하지 않습니다. 잠시 후 다시 시도해 주세요.'` SnackBar 표시 권장
+- `_playLoginTransitionAnimation()` 완료 후 `navigatorKey.currentContext`로 표시
+
+---
+
+## 📁 영향 파일 목록
+
+```
+lib/
+├── screens/
+│   └── splash_screen.dart                       ← 핵심 변경 (전체 timeout)
+└── utils/
+    └── log_http_client_interceptor.dart         ← HTTP 레벨 timeout 추가
+```
+
+**변경 불필요** (이미 에러 처리 존재):
+- `lib/services/apis/app_version_api.dart` — try-catch로 null 반환 처리됨
+- `lib/services/apis/rom_auth_api.dart` — try-catch로 false 반환 처리됨
+- `lib/models/user_info.dart` — 로컬 SharedPreferences, 네트워크 없음
+- `lib/services/member_manager_service.dart` — try-catch로 null 반환 처리됨
+
+---
+
+## 다음 단계
+
+→ `/implement`로 구현 진행 (변경 대상 2개 파일, 소규모)

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -22,7 +22,9 @@ import 'package:romrom_fe/services/member_manager_service.dart';
 import 'package:romrom_fe/services/token_manager.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/utils/deep_link_router.dart';
+import 'package:romrom_fe/enums/snack_bar_type.dart';
 import 'package:romrom_fe/widgets/auth_button_group.dart';
+import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/login_button.dart';
 
 class SplashScreen extends StatefulWidget {
@@ -73,11 +75,21 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
       debugPrint('[SplashScreen] 초기화 타임아웃 (${_splashTimeout.inSeconds}초) — 로그인 화면으로 이동');
       if (!mounted) return;
       await _playLoginTransitionAnimation();
+      _showNetworkErrorSnackBar();
     } catch (e, st) {
       debugPrint('[SplashScreen] 초기화 실패: $e\n$st');
       if (!mounted) return;
       await _playLoginTransitionAnimation();
+      // 네트워크 관련 오류(연결 불가, 타임아웃)일 때만 SnackBar 표시
+      if (e is SocketException || e is TimeoutException) {
+        _showNetworkErrorSnackBar();
+      }
     }
+  }
+
+  void _showNetworkErrorSnackBar() {
+    if (!mounted) return;
+    CommonSnackBar.show(context: context, message: '서버 연결이 원활하지 않습니다. 잠시 후 다시 시도해 주세요.', type: SnackBarType.error);
   }
 
   Future<void> _runInitFlow() async {

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -61,44 +61,57 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
     unawaited(_initAndNavigate());
   }
 
+  /// 스플래시 초기화 전체 타임아웃 (15초)
+  /// 개별 HTTP 요청 타임아웃(10초)이 1차 방어, 이 값은 2차 안전망
+  static const Duration _splashTimeout = Duration(seconds: 15);
+
   Future<void> _initAndNavigate() async {
     try {
-      final updateType = await AppVersionApi().checkUpdateType();
-      if (updateType == UpdateType.force && mounted) {
-        context.navigateTo(screen: const AppUpdateScreen(), type: NavigationTypes.fadeTransition);
-        return;
-      }
-
-      final results = await Future.wait([_determineInitialScreen(), Future.delayed(const Duration(seconds: 2))]);
-      final nextScreen = results[0]! as Widget;
-
+      // timeout() onTimeout 미제공 시 TimeoutException을 자동으로 throw
+      await _runInitFlow().timeout(_splashTimeout);
+    } on TimeoutException {
+      debugPrint('[SplashScreen] 초기화 타임아웃 (${_splashTimeout.inSeconds}초) — 로그인 화면으로 이동');
       if (!mounted) return;
-
-      if (nextScreen is LoginScreen) {
-        ColdStartDeepLinkData.clear(); // 미인증 상태 → 딥링크 데이터 폐기
-        await _playLoginTransitionAnimation();
-      } else {
-        context.navigateTo(screen: nextScreen, type: NavigationTypes.fadeTransition);
-        // MainScreen 이동 후 콜드 스타트 FCM/AppLinks 딥링크 처리
-        // (pushAndRemoveUntil이 완료된 다음 프레임에 navigatorKey로 push)
-        if (nextScreen is MainScreen && ColdStartDeepLinkData.hasPending) {
-          final pendingUri = ColdStartDeepLinkData.pendingUri!;
-          final pendingType = ColdStartDeepLinkData.pendingNotificationType;
-          ColdStartDeepLinkData.clear();
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            final ctx = navigatorKey.currentContext;
-            if (ctx != null) {
-              RomRomDeepLinkRouter.openFromUri(ctx, pendingUri, notificationType: pendingType);
-            }
-          });
-        } else {
-          ColdStartDeepLinkData.clear(); // 온보딩 등 비대상 화면 → 딥링크 데이터 폐기
-        }
-      }
+      await _playLoginTransitionAnimation();
     } catch (e, st) {
       debugPrint('[SplashScreen] 초기화 실패: $e\n$st');
       if (!mounted) return;
       await _playLoginTransitionAnimation();
+    }
+  }
+
+  Future<void> _runInitFlow() async {
+    final updateType = await AppVersionApi().checkUpdateType();
+    if (updateType == UpdateType.force && mounted) {
+      context.navigateTo(screen: const AppUpdateScreen(), type: NavigationTypes.fadeTransition);
+      return;
+    }
+
+    final results = await Future.wait([_determineInitialScreen(), Future.delayed(const Duration(seconds: 2))]);
+    final nextScreen = results[0]! as Widget;
+
+    if (!mounted) return;
+
+    if (nextScreen is LoginScreen) {
+      ColdStartDeepLinkData.clear(); // 미인증 상태 → 딥링크 데이터 폐기
+      await _playLoginTransitionAnimation();
+    } else {
+      context.navigateTo(screen: nextScreen, type: NavigationTypes.fadeTransition);
+      // MainScreen 이동 후 콜드 스타트 FCM/AppLinks 딥링크 처리
+      // (pushAndRemoveUntil이 완료된 다음 프레임에 navigatorKey로 push)
+      if (nextScreen is MainScreen && ColdStartDeepLinkData.hasPending) {
+        final pendingUri = ColdStartDeepLinkData.pendingUri!;
+        final pendingType = ColdStartDeepLinkData.pendingNotificationType;
+        ColdStartDeepLinkData.clear();
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          final ctx = navigatorKey.currentContext;
+          if (ctx != null) {
+            RomRomDeepLinkRouter.openFromUri(ctx, pendingUri, notificationType: pendingType);
+          }
+        });
+      } else {
+        ColdStartDeepLinkData.clear(); // 온보딩 등 비대상 화면 → 딥링크 데이터 폐기
+      }
     }
   }
 

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -40,6 +40,7 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
   late Animation<double> _loginUIFadeAnim;
   bool _showLoginUI = false;
   bool _loginTransitionStarted = false;
+  bool _aborted = false;
 
   @override
   void initState() {
@@ -73,11 +74,15 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
       await _runInitFlow().timeout(_splashTimeout);
     } on TimeoutException {
       debugPrint('[SplashScreen] 초기화 타임아웃 (${_splashTimeout.inSeconds}초) — 로그인 화면으로 이동');
+      _aborted = true; // _runInitFlow()가 백그라운드에서 완료되더라도 navigation/딥링크 차단
+      ColdStartDeepLinkData.clear(); // 중단 시 대기 중인 딥링크 폐기
       if (!mounted) return;
       await _playLoginTransitionAnimation();
       _showNetworkErrorSnackBar();
     } catch (e, st) {
       debugPrint('[SplashScreen] 초기화 실패: $e\n$st');
+      _aborted = true; // _runInitFlow()가 백그라운드에서 완료되더라도 navigation/딥링크 차단
+      ColdStartDeepLinkData.clear(); // 중단 시 대기 중인 딥링크 폐기
       if (!mounted) return;
       await _playLoginTransitionAnimation();
       // 네트워크 관련 오류(연결 불가, 타임아웃)일 때만 SnackBar 표시
@@ -94,12 +99,15 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
 
   Future<void> _runInitFlow() async {
     final updateType = await AppVersionApi().checkUpdateType();
+    // _aborted: timeout 또는 오류로 _initAndNavigate()가 이미 로그인 화면을 표시한 경우
+    if (_aborted) return;
     if (updateType == UpdateType.force && mounted) {
       context.navigateTo(screen: const AppUpdateScreen(), type: NavigationTypes.fadeTransition);
       return;
     }
 
     final results = await Future.wait([_determineInitialScreen(), Future.delayed(const Duration(seconds: 2))]);
+    if (_aborted) return; // Future.wait 대기 중 타임아웃이 발생했을 수 있음
     final nextScreen = results[0]! as Widget;
 
     if (!mounted) return;
@@ -116,6 +124,7 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
         final pendingType = ColdStartDeepLinkData.pendingNotificationType;
         ColdStartDeepLinkData.clear();
         WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (_aborted) return; // 프레임 콜백 실행 전 중단됐을 경우 딥링크 라우팅 차단
           final ctx = navigatorKey.currentContext;
           if (ctx != null) {
             RomRomDeepLinkRouter.openFromUri(ctx, pendingUri, notificationType: pendingType);
@@ -211,6 +220,8 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
       await FirebaseService().handleFcmToken();
       return MainScreen(key: MainScreen.globalKey);
     } catch (e) {
+      // 네트워크 예외는 재throw → _initAndNavigate()의 catch에서 SnackBar 표시
+      if (e is SocketException || e is TimeoutException) rethrow;
       debugPrint('[SplashScreen] 사용자 정보 로드 실패: $e');
       return const LoginScreen();
     }

--- a/lib/services/apple_auth_service.dart
+++ b/lib/services/apple_auth_service.dart
@@ -188,10 +188,16 @@ class AppleAuthService {
         throw EmailAlreadyRegisteredException(registeredSocialPlatform: '');
       }
       debugPrint('애플 로그인 실패: $e');
-      return false;
+      rethrow; // 실패는 위로 전파 → LoginButton에서 SnackBar 표시
+    } on SignInWithAppleAuthorizationException catch (e) {
+      if (e.code == AuthorizationErrorCode.canceled) {
+        return false; // 사용자 취소는 조용히 처리
+      }
+      debugPrint('애플 로그인 실패: $e');
+      rethrow; // 취소 외 오류는 위로 전파 → LoginButton에서 SnackBar 표시
     } catch (error) {
       debugPrint('애플 로그인 실패: $error');
-      return false;
+      rethrow; // 실패는 위로 전파 → LoginButton에서 SnackBar 표시
     }
   }
 

--- a/lib/services/google_auth_service.dart
+++ b/lib/services/google_auth_service.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart' hide UserInfo;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
 import 'package:romrom_fe/enums/login_platforms.dart';
@@ -80,10 +81,14 @@ class GoogleAuthService {
         throw EmailAlreadyRegisteredException(registeredSocialPlatform: '');
       }
       debugPrint('구글로 로그인 실패: $e');
-      return false;
+      rethrow; // 실패는 위로 전파 → LoginButton에서 SnackBar 표시
     } catch (error) {
       debugPrint('구글로 로그인 실패: $error');
-      return false;
+      // google_sign_in: 사용자 취소 시 PlatformException(code: 'sign_in_canceled') 발생
+      if (error is PlatformException && error.code == 'sign_in_canceled') {
+        return false; // 사용자 취소는 조용히 처리
+      }
+      rethrow; // 취소 외 오류는 위로 전파 → LoginButton에서 SnackBar 표시
     }
   }
 

--- a/lib/services/google_auth_service.dart
+++ b/lib/services/google_auth_service.dart
@@ -84,7 +84,11 @@ class GoogleAuthService {
       rethrow; // 실패는 위로 전파 → LoginButton에서 SnackBar 표시
     } catch (error) {
       debugPrint('구글로 로그인 실패: $error');
-      // google_sign_in: 사용자 취소 시 PlatformException(code: 'sign_in_canceled') 발생
+      // google_sign_in 7.x: 사용자 취소 시 GoogleSignInException(code: canceled) 발생
+      if (error is GoogleSignInException && error.code == GoogleSignInExceptionCode.canceled) {
+        return false; // 사용자 취소는 조용히 처리
+      }
+      // google_sign_in 6.x 폴백: 사용자 취소 시 PlatformException(code: 'sign_in_canceled') 발생
       if (error is PlatformException && error.code == 'sign_in_canceled') {
         return false; // 사용자 취소는 조용히 처리
       }

--- a/lib/services/kakao_auth_service.dart
+++ b/lib/services/kakao_auth_service.dart
@@ -135,14 +135,13 @@ class KakaoAuthService {
         throw EmailAlreadyRegisteredException(registeredSocialPlatform: '');
       }
       debugPrint('카카오톡으로 로그인 실패: $e');
-      return false;
+      rethrow; // 실패는 위로 전파 → LoginButton에서 SnackBar 표시
     } catch (error) {
       debugPrint('카카오톡으로 로그인 실패: $error');
-
       if (error is PlatformException && error.code == 'CANCELED') {
-        return false; // 사용자가 로그인 취소 시 false 반환
+        return false; // 사용자 취소는 조용히 처리
       }
-      return false; // 카카오 계정 로그인 폴백 제거 (aud 불일치 방지)
+      rethrow; // 취소 외 오류는 위로 전파 → LoginButton에서 SnackBar 표시
     }
   }
 

--- a/lib/utils/log_http_client_interceptor.dart
+++ b/lib/utils/log_http_client_interceptor.dart
@@ -6,6 +6,10 @@ import 'package:http/http.dart' as http;
 class LoggingHttpClient extends http.BaseClient {
   final http.Client _inner;
 
+  /// 기본 HTTP 요청 타임아웃 (10초)
+  /// 파일 업로드 등 장시간 작업은 별도 클라이언트 사용 권장
+  static const Duration defaultTimeout = Duration(seconds: 10);
+
   LoggingHttpClient(this._inner);
 
   String _prettyJson(dynamic json) {
@@ -53,8 +57,19 @@ class LoggingHttpClient extends http.BaseClient {
     }
 
     try {
-      // 실제 요청 전송
-      final streamedResponse = await _inner.send(request);
+      // 실제 요청 전송 (타임아웃 적용)
+      final streamedResponse = await _inner
+          .send(request)
+          .timeout(
+            defaultTimeout,
+            onTimeout: () {
+              final duration = DateTime.now().difference(startTime).inMilliseconds;
+              debugPrint("[${_formatTime(DateTime.now())}] [Timeout] ${request.url} [uid: $requestId]");
+              debugPrint("   [Duration] ${duration}ms (${defaultTimeout.inSeconds}s 초과)");
+              debugPrint("====================================");
+              throw TimeoutException('HTTP 타임아웃: ${request.url}', defaultTimeout);
+            },
+          );
       final duration = DateTime.now().difference(startTime).inMilliseconds;
 
       // 전체 응답 본문 읽기

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1107,10 +1107,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1672,10 +1672,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1107,10 +1107,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1672,10 +1672,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
#865 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 백엔드 무응답 시 스플래시 화면 무한로딩 문제를 해결했습니다.
  * HTTP 요청 타임아웃(기본 10초) 적용으로 무응답 처리 속도를 개선했습니다.

* **Improvements**
  * 스플래시 초기화 흐름에 타임아웃(예: 15초)과 네트워크 오류 안내를 추가했습니다.
  * Apple/Google/Kakao 소셜 로그인 오류 처리를 개선해 취소는 조용히 처리하고 그 외 오류는 상위에서 표시하도록 변경했습니다.

* **Documentation**
  * 스플래시 무한로딩 이슈 분석 보고서를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-ROMROM/RomRom-FE/pull/866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->