### PR TITLE
물품 등록·프로필 이미지 클라이언트 측 압축 (기기에서 WebP 압축 후 업로드)

### DIFF
--- a/docs/superpowers/plans/2026-05-28-client-side-image-compression.md
+++ b/docs/superpowers/plans/2026-05-28-client-side-image-compression.md
@@ -1,0 +1,417 @@
+# 클라이언트 측 이미지 압축 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 물품 등록·프로필 이미지를 업로드 전 기기에서 WebP(가로 1280, Q80)로 압축하여 백엔드 압축 부하·대기시간을 줄인다.
+
+**Architecture:** 공통 유틸 `ImageCompressor.toWebp(XFile) → Future<XFile>` 하나가 압축 책임을 전담한다(실패 시 원본 반환). 물품 등록은 "선택 즉시 백그라운드 압축" 패턴(`Map<path, Future<XFile>>`)으로 사용자에게 압축을 숨기고, 등록 시 `Future.wait` 로 모은다. 프로필은 단일 이미지라 업로드 직전 1회 await.
+
+**Tech Stack:** Flutter, `flutter_image_compress`(신규), `image_picker`(기존), `path_provider`(임시파일 경로).
+
+---
+
+## 환경 제약 (중요 — 모든 Task 공통)
+
+- **내부망 환경**: `flutter pub get`·`flutter test`·`flutter analyze`·`flutter build` 는 외부 의존성 다운로드가 필요하여 **이 환경에서 실행 불가**. 코드·테스트 코드는 작성하되, 실행/검증은 사용자가 외부 환경에서 수행한다.
+- 따라서 각 Task 의 "Run test" 스텝은 **사용자 환경 실행용**으로 명시한다. 에이전트는 명령을 실행하지 말고, 코드 작성 완료 후 `dart format --line-length=120 .` 만 적용한다(포매팅은 외부 연결 불필요).
+- **커밋 금지**: 사용자 명시 승인 없이 `git add`/`git commit` 절대 실행 금지(프로젝트 절대 규칙). 각 Task 의 "Commit" 스텝은 **사용자가 직접 실행**하거나 `/cassiiopeia:commit` 으로 처리. 에이전트는 커밋하지 않는다.
+- 작업 디렉터리: worktree `D:\0-suh\project\RomRom-FE-Worktree\20260528_887_기능개선_물품등록_프로필_이미지_클라이언트_측_압축`.
+
+---
+
+## File Structure
+
+| 파일 | 책임 | 종류 |
+|------|------|------|
+| `pubspec.yaml` | `flutter_image_compress` 의존성 선언 | 수정 |
+| `lib/utils/image_compressor.dart` | WebP 압축 단일 책임 유틸 (`toWebp`) | 생성 |
+| `lib/widgets/register_input_form.dart` | 물품 등록: 선택 즉시 백그라운드 압축, 등록 시 await | 수정 |
+| `lib/widgets/profile/profile_overview_section.dart` | 프로필: 크롭 결과 업로드 직전 압축 | 수정 |
+| `test/utils/image_compressor_test.dart` | `ImageCompressor` 단위 테스트 | 생성 |
+
+`ImageApi.uploadImages` 및 업로드 API 계약은 변경하지 않는다(멀티파트 key `images`, `POST /api/image/upload`).
+
+---
+
+## Task 1: 패키지 추가
+
+**Files:**
+- Modify: `pubspec.yaml`
+
+- [ ] **Step 1: `flutter_image_compress` 의존성 추가**
+
+`pubspec.yaml` 의 `dependencies:` 섹션에서 `image_picker` 항목 바로 아래에 추가한다.
+
+```yaml
+  image_picker: ^1.1.2
+  flutter_image_compress: ^2.3.0
+```
+
+> 버전 `^2.3.0` 은 작성 시점 안정 버전. 사용자 환경 pub 캐시에 맞는 버전이 다르면 사용자가 조정한다.
+
+- [ ] **Step 2: (사용자 환경) 의존성 설치**
+
+Run (사용자 외부 환경): `flutter pub get`
+Expected: `flutter_image_compress` 해석 성공, `Got dependencies!`
+
+- [ ] **Step 3: Commit (사용자 승인 후)**
+
+```bash
+git add pubspec.yaml pubspec.lock
+git commit -m "물품 등록·프로필 이미지 클라이언트 측 압축 : chore : flutter_image_compress 의존성 추가 https://github.com/TEAM-ROMROM/RomRom-FE/issues/887"
+```
+
+---
+
+## Task 2: 공통 압축 유틸 `ImageCompressor`
+
+**Files:**
+- Create: `lib/utils/image_compressor.dart`
+- Test: `test/utils/image_compressor_test.dart`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+`test/utils/image_compressor_test.dart` 생성. `flutter_image_compress` 는 네이티브 플러그인이라 순수 단위 테스트에서 인코딩이 동작하지 않으므로, **실패 fallback 동작**(존재하지 않는 경로 → 원본 XFile 그대로 반환, throw 안 함)을 검증 대상으로 한다. 이 동작이 안전망의 핵심이다.
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:romrom_fe/utils/image_compressor.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ImageCompressor.toWebp', () {
+    test('존재하지 않는 파일이면 원본 XFile을 그대로 반환하고 throw하지 않는다', () async {
+      const sourcePath = '/non/existent/path/fake.jpg';
+      final source = XFile(sourcePath);
+
+      final result = await ImageCompressor.toWebp(source);
+
+      expect(result.path, sourcePath);
+    });
+
+    test('상수값이 BE와 동일하다 (가로 1280, Q80)', () {
+      expect(ImageCompressor.targetWidth, 1280);
+      expect(ImageCompressor.quality, 80);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: (사용자 환경) 테스트 실패 확인**
+
+Run (사용자 외부 환경): `flutter test test/utils/image_compressor_test.dart`
+Expected: FAIL — `image_compressor.dart` 없음 / `ImageCompressor` 미정의로 컴파일 에러.
+
+- [ ] **Step 3: `ImageCompressor` 구현**
+
+`lib/utils/image_compressor.dart` 생성.
+
+```dart
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// 이미지를 WebP로 압축하는 공통 유틸.
+///
+/// 산출물은 현 백엔드(ImageCompressionService)와 동일: 가로 1280 축소(비율 유지),
+/// WebP Q80. 압축 실패 시 원본 XFile을 그대로 반환한다(백엔드 조건부 압축이 안전망).
+class ImageCompressor {
+  ImageCompressor._();
+
+  /// 백엔드 scaleToWidth(1280)와 동일한 가로 기준값.
+  static const int targetWidth = 1280;
+
+  /// 백엔드 QUALITY=80과 동일.
+  static const int quality = 80;
+
+  /// 단일 이미지를 WebP로 압축. 실패하면 원본 [source]를 그대로 반환(throw 안 함).
+  static Future<XFile> toWebp(XFile source) async {
+    try {
+      final dir = await getTemporaryDirectory();
+      final fileName = 'cmp_${DateTime.now().microsecondsSinceEpoch}.webp';
+      final targetPath = '${dir.path}/$fileName';
+
+      final XFile? result = await FlutterImageCompress.compressAndGetFile(
+        source.path,
+        targetPath,
+        format: CompressFormat.webp,
+        quality: quality,
+        // 긴 변 기준 비율 유지 축소. 가로/세로 모두 targetWidth 이하로 맞춰지며
+        // 원본이 더 작으면 확대하지 않는다(비율 보존).
+        minWidth: targetWidth,
+        minHeight: targetWidth,
+      );
+
+      if (result == null) {
+        debugPrint('ImageCompressor: 압축 결과 null, 원본 사용 (${source.path})');
+        return source;
+      }
+      return XFile(result.path);
+    } catch (e) {
+      debugPrint('ImageCompressor: 압축 실패, 원본 사용 ($e)');
+      return source;
+    }
+  }
+}
+```
+
+> `path_provider` 는 RomRom-FE 에 이미 포함되어 있다(크롭 화면 등에서 사용 중). 미포함 시 Task 1 에 `path_provider` 추가.
+
+- [ ] **Step 4: (사용자 환경) 테스트 통과 확인**
+
+Run (사용자 외부 환경): `flutter test test/utils/image_compressor_test.dart`
+Expected: PASS (2 tests). 존재하지 않는 경로 → catch → 원본 반환.
+
+- [ ] **Step 5: 포매팅**
+
+Run: `dart format --line-length=120 lib/utils/image_compressor.dart test/utils/image_compressor_test.dart`
+
+- [ ] **Step 6: Commit (사용자 승인 후)**
+
+```bash
+git add lib/utils/image_compressor.dart test/utils/image_compressor_test.dart
+git commit -m "물품 등록·프로필 이미지 클라이언트 측 압축 : feat : WebP 압축 공통 유틸 ImageCompressor 추가 https://github.com/TEAM-ROMROM/RomRom-FE/issues/887"
+```
+
+---
+
+## Task 3: 물품 등록 — 선택 즉시 백그라운드 압축
+
+**Files:**
+- Modify: `lib/widgets/register_input_form.dart`
+  - 상태 필드 추가: line 94 인근(`_newImageFiles` 선언 아래)
+  - 압축 시작: `onPickImage` 카메라(line 135) / 갤러리(line 146)
+  - 압축 결과 정리: `onDeleteImage`(line 172), `_initControllers` clear(line 232)
+  - 등록 시 await: 제출 핸들러(line 833~838)
+
+`ImageCompressor` 가 이미 단위 테스트로 검증되었으므로, 이 Task 는 호출부 배선 변경이다. 위젯 통합 테스트는 내부망에서 image_picker 네이티브 호출 모킹이 어려워 수동 QA 로 검증한다(테스트케이스는 Phase 5 에서 작성).
+
+- [ ] **Step 1: import 추가**
+
+`register_input_form.dart` 상단 import 블록에 추가(기존 import 정렬에 맞춰 알파벳 순 위치).
+
+```dart
+import 'package:romrom_fe/utils/image_compressor.dart';
+```
+
+- [ ] **Step 2: 백그라운드 압축 상태 필드 추가**
+
+line 94 `final List<XFile> _newImageFiles = [];` 바로 아래에 추가.
+
+```dart
+  final List<XFile> _newImageFiles = []; // 새로 선택된 로컬 이미지 파일 (아직 업로드 안 됨)
+  // 선택 즉시 시작한 백그라운드 압축 Future. key=원본 XFile.path, value=압축된 XFile.
+  // 등록 시 await로 수거. 삭제되면 맵에서 빠져 결과가 버려진다(취소 API 없음).
+  final Map<String, Future<XFile>> _compressing = {};
+```
+
+- [ ] **Step 3: 카메라 선택 시 백그라운드 압축 시작**
+
+`onPickImage` 카메라 케이스(line 133-136):
+
+```dart
+          if (!mounted) return;
+          setState(() {
+            _newImageFiles.add(shot);
+          });
+```
+
+를 아래로 교체.
+
+```dart
+          if (!mounted) return;
+          setState(() {
+            _newImageFiles.add(shot);
+          });
+          _compressing[shot.path] = ImageCompressor.toWebp(shot);
+```
+
+- [ ] **Step 4: 갤러리 선택 시 백그라운드 압축 시작**
+
+`onPickImage` 갤러리 케이스(line 144-147):
+
+```dart
+          if (!mounted) return;
+          setState(() {
+            _newImageFiles.addAll(toAdd);
+          });
+```
+
+를 아래로 교체.
+
+```dart
+          if (!mounted) return;
+          setState(() {
+            _newImageFiles.addAll(toAdd);
+          });
+          for (final x in toAdd) {
+            _compressing[x.path] = ImageCompressor.toWebp(x);
+          }
+```
+
+- [ ] **Step 5: 삭제 시 압축 결과 버리기**
+
+`onDeleteImage` 의 로컬 이미지 삭제 분기(line 170-173):
+
+```dart
+      } else {
+        // 새로 추가된 로컬 이미지 삭제
+        _newImageFiles.removeAt(index - existingCount);
+      }
+```
+
+를 아래로 교체(삭제 대상의 path 를 먼저 구해 맵에서 제거).
+
+```dart
+      } else {
+        // 새로 추가된 로컬 이미지 삭제
+        final removed = _newImageFiles.removeAt(index - existingCount);
+        _compressing.remove(removed.path); // 진행 중 압축 결과 버림
+      }
+```
+
+- [ ] **Step 6: 수정 모드 초기화 시 맵도 clear**
+
+`_initControllers` 의 line 232:
+
+```dart
+      _newImageFiles.clear();
+```
+
+를 아래로 교체.
+
+```dart
+      _newImageFiles.clear();
+      _compressing.clear();
+```
+
+- [ ] **Step 7: 등록/수정 제출 시 압축본 수거 후 업로드**
+
+제출 핸들러(line 831-838):
+
+```dart
+                        // 새 로컬 이미지가 있으면 서버에 업로드
+                        List<String> newImageUrls = [];
+                        if (_newImageFiles.isNotEmpty) {
+                          newImageUrls = await ImageApi().uploadImages(_newImageFiles);
+                          if (newImageUrls.length != _newImageFiles.length) {
+                            throw Exception('일부 이미지 업로드에 실패했습니다 (${newImageUrls.length}/${_newImageFiles.length})');
+                          }
+                        }
+```
+
+를 아래로 교체. `_newImageFiles` 순회로 압축 Future 를 매핑하여 **순서를 보존**한다. 이미 끝난 Future 는 즉시 반환(추가 대기 0), 진행 중이면 남은 만큼만 대기. 맵에 없으면(엣지) 그 자리에서 압축.
+
+```dart
+                        // 새 로컬 이미지가 있으면 압축본을 수거해 서버에 업로드
+                        List<String> newImageUrls = [];
+                        if (_newImageFiles.isNotEmpty) {
+                          // 선택 시 시작한 백그라운드 압축을 순서 보존하여 수거.
+                          // 보통 이미 완료되어 대기 0, 미완료분만 짧게 대기.
+                          final List<XFile> compressed = await Future.wait(
+                            _newImageFiles.map(
+                              (x) => _compressing[x.path] ?? ImageCompressor.toWebp(x),
+                            ),
+                          );
+                          newImageUrls = await ImageApi().uploadImages(compressed);
+                          if (newImageUrls.length != compressed.length) {
+                            throw Exception('일부 이미지 업로드에 실패했습니다 (${newImageUrls.length}/${compressed.length})');
+                          }
+                        }
+```
+
+- [ ] **Step 8: (사용자 환경) 분석·수동 QA**
+
+Run (사용자 외부 환경): `flutter analyze`
+Expected: No issues (또는 기존 대비 신규 경고 0).
+수동 QA: 다중 이미지 선택 → 즉시 등록(압축 미완료) → 정상 등록, URL 개수=이미지 개수, 순서 유지. 압축 중 1장 삭제 → 그 장 제외 등록.
+
+- [ ] **Step 9: 포매팅**
+
+Run: `dart format --line-length=120 lib/widgets/register_input_form.dart`
+
+- [ ] **Step 10: Commit (사용자 승인 후)**
+
+```bash
+git add lib/widgets/register_input_form.dart
+git commit -m "물품 등록·프로필 이미지 클라이언트 측 압축 : feat : 물품 등록 시 선택 즉시 백그라운드 WebP 압축 후 업로드 https://github.com/TEAM-ROMROM/RomRom-FE/issues/887"
+```
+
+---
+
+## Task 4: 프로필 이미지 — 업로드 직전 압축
+
+**Files:**
+- Modify: `lib/widgets/profile/profile_overview_section.dart`
+  - import 추가
+  - 업로드 직전 압축: line 111
+
+프로필은 단일 이미지이고 크롭 화면 이후 한 번만 업로드하므로 백그라운드 패턴이 불필요하다. 크롭 산출 PNG 를 업로드 직전에 `ImageCompressor.toWebp` 1회 통과시킨다. 500x500 이라 리사이즈는 사실상 미적용(1280 미만), WebP Q80 변환만 적용되어 무손실 PNG 대비 용량 감소.
+
+- [ ] **Step 1: import 추가**
+
+`profile_overview_section.dart` 상단 import 블록에 추가.
+
+```dart
+import 'package:romrom_fe/utils/image_compressor.dart';
+```
+
+- [ ] **Step 2: 업로드 직전 압축 적용**
+
+line 110-111:
+
+```dart
+      try {
+        final List<String> urls = await ImageApi().uploadImages([croppedFile]);
+```
+
+를 아래로 교체.
+
+```dart
+      try {
+        final XFile compressed = await ImageCompressor.toWebp(croppedFile);
+        final List<String> urls = await ImageApi().uploadImages([compressed]);
+```
+
+> `croppedFile` 은 이미 `XFile?` 의 non-null 분기(line 99-102 가드 통과 후) 이므로 `XFile` 로 사용 가능.
+
+- [ ] **Step 3: (사용자 환경) 분석·수동 QA**
+
+Run (사용자 외부 환경): `flutter analyze`
+Expected: No issues.
+수동 QA: 프로필 이미지 변경 → 크롭 → 저장 → 업로드 성공, 프로필 이미지 정상 표시.
+
+- [ ] **Step 4: 포매팅**
+
+Run: `dart format --line-length=120 lib/widgets/profile/profile_overview_section.dart`
+
+- [ ] **Step 5: Commit (사용자 승인 후)**
+
+```bash
+git add lib/widgets/profile/profile_overview_section.dart
+git commit -m "물품 등록·프로필 이미지 클라이언트 측 압축 : feat : 프로필 이미지 업로드 직전 WebP 압축 적용 https://github.com/TEAM-ROMROM/RomRom-FE/issues/887"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 패키지 추가 → Task 1 ✓
+- 공통 유틸 `ImageCompressor.toWebp`(WebP/1280/Q80, 실패 시 원본) → Task 2 ✓
+- 물품 선택 즉시 백그라운드 압축(`Map<path,Future>`) / 등록 시 `Future.wait` / 삭제 시 결과 버림 / 순서 보존 → Task 3 ✓
+- 프로필 크롭 PNG → 업로드 직전 WebP → Task 4 ✓
+- 실패 fallback(원본 전송) → Task 2 구현 + Task 2 테스트로 검증 ✓
+- 비율 보존 → `minWidth/minHeight` 비율 유지 축소(Task 2 주석 명시) ✓
+- BE 조건부 압축 → 본 plan 범위 밖(별도 이슈), spec 에 명시 ✓
+
+**Placeholder scan:** "TBD"/"적절히 처리"/"비슷하게" 등 없음. 모든 코드 스텝에 실제 코드 포함. ✓
+
+**Type consistency:** `ImageCompressor.toWebp(XFile) → Future<XFile>`, `targetWidth`/`quality` 상수, `_compressing: Map<String, Future<XFile>>` — Task 2~4 전체에서 동일 시그니처·이름 사용. ✓
+
+**환경 제약 반영:** 모든 test/analyze 스텝에 "(사용자 외부 환경)" 명시, 에이전트 커밋 금지 명시. ✓

--- a/docs/superpowers/specs/2026-05-28-client-side-image-compression-design.md
+++ b/docs/superpowers/specs/2026-05-28-client-side-image-compression-design.md
@@ -1,0 +1,132 @@
+# 클라이언트 측 이미지 압축 설계
+
+- 날짜: 2026-05-28
+- 대상 레포: RomRom-FE (이번 구현). RomRom-BE 는 별도 이슈만 생성.
+- 관련 배경: 물품 등록/프로필 이미지 업로드 시 BE 가 모든 이미지를 동기 순차로 WebP 압축(`ImageCompressionService`, scrimage-webp→네이티브 cwebp). 이미지 N장이 직렬 처리되어 업로드 응답이 느림.
+
+## 목표
+
+이미지 압축을 **기기(클라이언트)** 에서 수행하여 BE 압축 부하·대기시간을 줄인다.
+
+- FE 가 업로드 전에 WebP 로 압축(현 BE 와 동일한 산출물: 가로 1280 축소, Q80).
+- 사용자에게 압축 과정을 **숨긴다**: 이미지 선택 즉시 백그라운드 압축을 시작하고, 미리보기는 원본으로 즉시 표시. 사용자가 폼을 채우는 동안 압축이 끝나므로 등록 시점엔 보통 이미 완료되어 추가 대기가 없다.
+- 압축 결과물·파라미터를 **공통 유틸 함수**로 추출하여 물품 등록과 프로필 이미지에 함께 사용.
+
+## 비목표 (이번 범위 밖)
+
+- BE 압축 로직 변경 — 별도 이슈로 트래킹(동일 PAT, `/cassiiopeia:github`). 이번 PR 은 FE 만.
+- 업로드 API 계약(`POST /api/image/upload`, multipart key `images`) 변경 없음.
+- 이미지 크롭 UX 변경 없음(프로필 크롭 화면 동작 유지).
+
+## 압축 스펙
+
+| 항목 | 값 | 근거 |
+|------|----|----|
+| 출력 포맷 | WebP | 현 BE 산출물과 동일. BE 조건부 압축이 "이미 WebP면 스킵" 판단 쉬움 |
+| 리사이즈 | 가로 1280 기준 축소(비율 유지, 긴 변 기준) | 현 BE `scaleToWidth(1280)` 와 동일. 1280 이하 원본은 리사이즈 생략 |
+| 품질 | Q80 | 현 BE `QUALITY=80` 과 동일 |
+| 비율 | **원본 그대로** | 리사이즈는 비율 유지 축소만, Q80 은 화질만 조정 → 왜곡 없음 |
+| 예상 용량 | 원본의 5~15% (4MB 사진 → 약 250KB) | 1280 다운스케일(~1/9 픽셀) + WebP(JPEG 대비 -30%) |
+
+리사이즈 매핑: `flutter_image_compress` 는 가로/세로를 직접 지정하지 않고 `minWidth`/`minHeight` 로 "긴 변이 이 값 이상이면 그 비율로 축소"한다. 가로 1280 동작을 재현하려면 `minWidth: 1280, minHeight: 1280` 으로 두고 비율 유지에 맡긴다(세로가 더 긴 사진도 긴 변이 1280 으로 맞춰짐 — BE 의 "가로만 1280" 과 미세하게 다를 수 있으나, 둘 다 비율 유지 축소이고 용량 목표는 동일하므로 허용). 정확히 가로 기준만 제한해야 하면 `minHeight` 를 매우 크게(예: 100000) 두어 가로만 제약하는 방식으로 조정한다.
+
+## 패키지
+
+- `flutter_image_compress` 추가(pubspec.yaml).
+- iOS/Android 모두 네이티브 스레드에서 WebP 인코딩 → UI 멈춤 없음. 별도 `Isolate` 불필요.
+- **내부망 제약**: `flutter pub get` 은 사용자가 외부 환경에서 직접 수행. 구현 중 패키지 미설치로 analyze 실패할 수 있음 — 코드 작성은 진행하되 빌드/analyze 는 사용자 환경에서 검증.
+
+## 컴포넌트
+
+### 1) 공통 유틸 — `ImageCompressor`
+
+위치: `lib/utils/image_compressor.dart` (신규)
+
+```
+class ImageCompressor {
+  static const int targetWidth = 1280;
+  static const int quality = 80;
+
+  /// 단일 이미지를 WebP로 압축. 실패 시 원본 XFile 그대로 반환(throw 안 함).
+  static Future<XFile> toWebp(XFile source) async { ... }
+}
+```
+
+- 입력 `XFile` → `flutter_image_compress` 로 WebP 압축 → 임시 디렉터리에 산출(`getTemporaryDirectory`) → 압축본 경로의 새 `XFile` 반환.
+- **실패 fallback**: 압축이 예외를 던지거나 결과가 null 이면 **원본 `XFile` 을 그대로 반환**(로그만 남김). BE 조건부 압축이 안전망이므로 원본이 가도 BE 가 압축한다. 업로드 실패 0, 사용자 끊김 없음.
+- 한 가지 책임만 가짐: "XFile 하나 → 압축된 XFile 하나". 호출부가 단일/다중·동기/백그라운드를 결정.
+
+### 2) 물품 등록 적용 — `register_input_form.dart`
+
+선택 즉시 백그라운드 압축, 등록 시 await 패턴.
+
+상태:
+```
+final List<XFile> _newImageFiles = [];                 // 기존: 원본(미리보기용)
+final Map<String, Future<XFile>> _compressing = {};    // 신규: key=XFile.path, value=압축 Future
+```
+
+- **선택 시점**(`onPickImage`, line 135/146): `_newImageFiles.add(x)` 직후 `_compressing[x.path] = ImageCompressor.toWebp(x)` 로 백그라운드 압축 시작(await 하지 않음). 미리보기는 기존대로 `_newImageFiles` 의 원본 경로 사용 → 0 지연.
+- **삭제 시점**(`onDeleteImage`, line 159~): `_newImageFiles.removeAt` 과 함께 `_compressing.remove(path)`. 진행 중인 Future 는 취소 API 가 없으므로 **결과를 버리는 방식**(맵에서 빠지면 등록 시 참조 안 됨).
+- **등록/수정 제출**(line 833 직전): 업로드 전에 압축본 모음.
+  ```
+  if (_newImageFiles.isNotEmpty) {
+    final compressed = await Future.wait(
+      _newImageFiles.map((x) => _compressing[x.path] ?? ImageCompressor.toWebp(x)),
+    );
+    newImageUrls = await ImageApi().uploadImages(compressed);
+  }
+  ```
+  - 이미 끝난 Future → 즉시 반환(추가 대기 0). 진행 중 → 남은 만큼만 대기. 맵에 없으면(엣지) 그 자리에서 압축.
+  - 순서 보존: `_newImageFiles` 순회로 Future 매핑하므로 업로드 URL 순서 = 표시 순서 유지.
+  - 기존 로딩(`_isLoading` 스피너, line 827)이 이미 떠 있어 짧은 대기를 자연 흡수. 새 로딩 UI 불필요.
+- **clear 시점**(line 232): `_compressing.clear()` 동반.
+
+### 3) 프로필 이미지 적용 — `profile_overview_section.dart` / `profile_image_crop_screen.dart`
+
+- 현 흐름: 갤러리 선택 → 크롭 화면에서 500x500 **PNG**(무손실) → `ImageApi().uploadImages([croppedFile])`.
+- 변경: 크롭 산출 PNG(`XFile`)를 업로드 직전에 `ImageCompressor.toWebp` 통과.
+  - 500x500 이므로 리사이즈는 사실상 미적용(1280 미만) → WebP Q80 변환만 적용. PNG 무손실(수백 KB~1MB+) → WebP 약 30~80KB 로 감소.
+  - 단일 이미지라 백그라운드 패턴 불필요. 업로드 직전 1회 await 로 충분.
+- 적용 지점: `profile_overview_section.dart:111` `uploadImages([croppedFile])` 직전에 `final c = await ImageCompressor.toWebp(croppedFile);` → `uploadImages([c])`.
+
+## 데이터 흐름 (물품)
+
+```
+[갤러리/카메라 선택]
+   → _newImageFiles.add(원본)          (미리보기 = 원본, 즉시)
+   → _compressing[path] = toWebp(원본)  (백그라운드 시작, await 안 함)
+[사용자가 제목·설명·가격 입력]            (이 사이에 압축 완료됨)
+[등록 버튼]
+   → _isLoading = true (기존 스피너)
+   → await Future.wait(압축 Future들)    (보통 이미 완료 → 대기 0)
+   → uploadImages(압축본 List)           (key 'images', /api/image/upload)
+   → 반환 URL → itemImageUrls → postItem/updateItem
+```
+
+## 엣지 케이스
+
+| 케이스 | 처리 |
+|--------|------|
+| 압축 실패(권한/메모리/손상) | `toWebp` 가 원본 XFile 반환. 원본 업로드 → BE 가 압축. 사용자 영향 없음 |
+| 압축 중 이미지 삭제 | `_compressing.remove(path)`. Future 결과 버림(취소 API 없음) |
+| 등록 시 압축 미완료 | `Future.wait` 가 남은 분만 대기. 기존 로딩 스피너로 흡수 |
+| 맵에 Future 없음(예외 상황) | 제출 시점에 `?? toWebp(x)` 로 즉석 압축 |
+| 원본이 이미 1280 이하 | 리사이즈 생략, WebP 변환만(여전히 용량 감소) |
+| 화면 dispose 중 압축 콜백 | `mounted` 가드 — `_newImageFiles`/`_compressing` 는 setState 없이 갱신, await 후 `mounted` 확인 |
+
+## 테스트 관점
+
+- `ImageCompressor.toWebp`: 정상 이미지 → 더 작은 WebP XFile, 비율 보존(가로:세로 비 동일), 1280 초과 시 가로 ≤ 1280.
+- 실패 입력(손상 파일/없는 경로) → 원본 XFile 그대로 반환, throw 안 함.
+- 물품 등록: 다중 선택 후 즉시 등록(압축 미완료) → 정상 완료, URL 개수 = 이미지 개수, 순서 보존.
+- 압축 중 1장 삭제 → 등록 시 그 이미지 제외, 나머지 정상.
+- 프로필: 크롭 PNG → WebP 업로드, 프로필 URL 갱신 정상.
+- (내부망) analyze/빌드/실기기 테스트는 사용자 환경에서 수행.
+
+## BE 후속 이슈 (이번 PR 아님)
+
+별도 이슈로 등록(동일 PAT):
+- 조건부 압축 가드: 입력이 이미 WebP 거나 충분히 작으면 cwebp 스킵, 큰 경우만 압축.
+- `StorageService` for 루프 병렬화(`@Async`/`CompletableFuture` 또는 `parallelStream`) 검토 — 안전망 압축 경로의 지연 완화.
+- 목적: FE 압축본은 빠르게 통과시키고, 구버전 앱/원본 fallback 만 BE 가 압축하는 하이브리드.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -67,6 +67,11 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
   - Flutter (1.0.0)
+  - flutter_image_compress_common (1.0.0):
+    - Flutter
+    - Mantle
+    - SDWebImage
+    - SDWebImageWebPCoder
   - flutter_local_notifications (0.0.1):
     - Flutter
   - flutter_naver_map (1.4.2):
@@ -140,6 +145,21 @@ PODS:
     - Flutter
   - kakao_flutter_sdk_common (1.10.0):
     - Flutter
+  - libwebp (1.5.0):
+    - libwebp/demux (= 1.5.0)
+    - libwebp/mux (= 1.5.0)
+    - libwebp/sharpyuv (= 1.5.0)
+    - libwebp/webp (= 1.5.0)
+  - libwebp/demux (1.5.0):
+    - libwebp/webp
+  - libwebp/mux (1.5.0):
+    - libwebp/demux
+  - libwebp/sharpyuv (1.5.0)
+  - libwebp/webp (1.5.0):
+    - libwebp/sharpyuv
+  - Mantle (2.2.0):
+    - Mantle/extobjc (= 2.2.0)
+  - Mantle/extobjc (2.2.0)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -161,6 +181,12 @@ PODS:
     - Flutter
   - PromisesObjC (2.4.0)
   - RecaptchaInterop (101.0.0)
+  - SDWebImage (5.21.7):
+    - SDWebImage/Core (= 5.21.7)
+  - SDWebImage/Core (5.21.7)
+  - SDWebImageWebPCoder (0.15.0):
+    - libwebp (~> 1.0)
+    - SDWebImage/Core (~> 5.17)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -184,6 +210,7 @@ DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - Flutter (from `Flutter`)
+  - flutter_image_compress_common (from `.symlinks/plugins/flutter_image_compress_common/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_naver_map (from `.symlinks/plugins/flutter_naver_map/ios`)
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
@@ -227,11 +254,15 @@ SPEC REPOS:
     - GoogleUtilities
     - GTMAppAuth
     - GTMSessionFetcher
+    - libwebp
+    - Mantle
     - nanopb
     - NMapsGeometry
     - NMapsMap
     - PromisesObjC
     - RecaptchaInterop
+    - SDWebImage
+    - SDWebImageWebPCoder
 
 EXTERNAL SOURCES:
   app_links:
@@ -246,6 +277,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_messaging/ios"
   Flutter:
     :path: Flutter
+  flutter_image_compress_common:
+    :path: ".symlinks/plugins/flutter_image_compress_common/ios"
   flutter_local_notifications:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_naver_map:
@@ -290,15 +323,15 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
+  app_links: 585674be3c6661708e6cd794ab4f39fb9d8356f9
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  device_info_plus: 71ffc6ab7634ade6267c7a93088ed7e4f74e5896
+  device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
   Firebase: 9a58fdbc9d8655ed7b79a19cf9690bb007d3d46d
-  firebase_auth: e9031a1dbe04a90d98e8d11ff2302352a1c6d9e8
-  firebase_core: ee30637e6744af8e0c12a6a1e8a9718506ec2398
-  firebase_messaging: 343de01a8d3e18b60df0c6d37f7174c44ae38e02
+  firebase_auth: e7aec07fcada64e296cf237a61df9660e52842c2
+  firebase_core: 8d5e24676350f15dd111aa59a88a1ae26605f9ba
+  firebase_messaging: 834cfc0887393d3108cdb19da8e57655c54fd0e4
   FirebaseAppCheckInterop: ba3dc604a89815379e61ec2365101608d365cf7d
   FirebaseAuth: 4c289b1a43f5955283244a55cf6bd616de344be5
   FirebaseAuthInterop: 95363fe96493cb4f106656666a0768b420cba090
@@ -308,39 +341,44 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 6a14ab3d694ebd9f839c48d330da5547e9ca9dc0
   FirebaseMessaging: 7f42cfd10ec64181db4e01b305a613791c8e782c
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
-  flutter_naver_map: d9f447f1271059759d4d5e38c3b347d7ab2ba835
-  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
-  geocoding_ios: 33776c9ebb98d037b5e025bb0e7537f6dd19646e
-  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
+  flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
+  flutter_local_notifications: ff50f8405aaa0ccdc7dcfb9022ca192e8ad9688f
+  flutter_naver_map: a1f6df83f663d9770e01624ba97a2d34c4fe349b
+  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
+  geocoding_ios: eafacae6ad11a1eb56681f7d11df602a5fd49416
+  geolocator_apple: 66b711889fd333205763b83c9dcf0a57a28c7afd
   Google-Mobile-Ads-SDK: 4534fd2dfcd3f705c5485a6633c5188d03d4eed2
-  google_mobile_ads: df3008bafbe1f2ad6862f87334e560d2f047f902
-  google_sign_in_ios: 000870aa06da9b28d1d0bf7ef70ff0213059dd28
+  google_mobile_ads: 2ba32ffef4a026aa94f526774a40a14ca9662adf
+  google_sign_in_ios: 7336a3372ea93ea56a21e126a0055ffca3723601
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: fcee2257188d5eda57a5e2b6a715550ffff9206d
   GoogleUserMessagingPlatform: befe603da6501006420c206222acd449bba45a9c
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
-  in_app_review: 7dd1ea365263f834b8464673f9df72c80c17c937
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  kakao_flutter_sdk_common: 682b3606698f87467788598dc2dc09d4e6867fbd
+  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
+  in_app_review: 436034b18594851a7328d7f1c2ed5ec235b79cfc
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  kakao_flutter_sdk_common: a21740b9dd4900f96161f365a2b6ece7a97cbf4f
+  libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
+  Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   NMapsGeometry: 4e02554fa9880ef02ed96b075dc84355d6352479
   NMapsMap: 1964e6f9073301ad3cbe3a12235ba36f6f6cd905
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
-  patrol: cea8074f183a2a4232d0ebd10569ae05149ada42
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  path_provider_foundation: 0b743cbb62d8e47eab856f09262bb8c1ddcfe6ba
+  patrol: d49fcd015892f19189a4cec572f21f3c3358e761
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
-  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
-  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
-  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
-  webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
+  SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
+  SDWebImageWebPCoder: 0e06e365080397465cc73a7a9b472d8a3bd0f377
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
+  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
+  sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
+  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
+  webview_flutter_wkwebview: 29eb20d43355b48fe7d07113835b9128f84e3af4
 
 PODFILE CHECKSUM: ce2a4dd764e1c7aeed6a7cdc5e61d092b6dc6d32
 

--- a/lib/utils/image_compressor.dart
+++ b/lib/utils/image_compressor.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// 이미지를 WebP로 압축하는 공통 유틸.
+///
+/// 산출물은 현 백엔드(ImageCompressionService)와 동일: 가로 1280 축소(비율 유지),
+/// WebP Q80. 압축 실패 시 원본 XFile을 그대로 반환한다(백엔드 조건부 압축이 안전망).
+class ImageCompressor {
+  ImageCompressor._();
+
+  /// 백엔드 scaleToWidth(1280)와 동일한 가로 기준값.
+  static const int targetWidth = 1280;
+
+  /// 백엔드 QUALITY=80과 동일.
+  static const int quality = 80;
+
+  /// 단일 이미지를 WebP로 압축. 실패하면 원본 [source]를 그대로 반환(throw 안 함).
+  static Future<XFile> toWebp(XFile source) async {
+    try {
+      final dir = await getTemporaryDirectory();
+      final fileName = 'cmp_${DateTime.now().microsecondsSinceEpoch}.webp';
+      final targetPath = '${dir.path}/$fileName';
+
+      final XFile? result = await FlutterImageCompress.compressAndGetFile(
+        source.path,
+        targetPath,
+        format: CompressFormat.webp,
+        quality: quality,
+        // 긴 변 기준 비율 유지 축소. 가로/세로 모두 targetWidth 이하로 맞춰지며
+        // 원본이 더 작으면 확대하지 않는다(비율 보존).
+        minWidth: targetWidth,
+        minHeight: targetWidth,
+      );
+
+      if (result == null) {
+        debugPrint('ImageCompressor: 압축 결과 null, 원본 사용 (${source.path})');
+        return source;
+      }
+      return XFile(result.path);
+    } catch (e) {
+      debugPrint('ImageCompressor: 압축 실패, 원본 사용 ($e)');
+      return source;
+    }
+  }
+}

--- a/lib/utils/image_compressor.dart
+++ b/lib/utils/image_compressor.dart
@@ -1,6 +1,7 @@
+import 'dart:math';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:path_provider/path_provider.dart';
 
 /// 이미지를 WebP로 압축하는 공통 유틸.
@@ -20,7 +21,8 @@ class ImageCompressor {
   static Future<XFile> toWebp(XFile source) async {
     try {
       final dir = await getTemporaryDirectory();
-      final fileName = 'cmp_${DateTime.now().microsecondsSinceEpoch}.webp';
+      final nonce = Random().nextInt(1 << 32);
+      final fileName = 'cmp_${DateTime.now().microsecondsSinceEpoch}_$nonce.webp';
       final targetPath = '${dir.path}/$fileName';
 
       final XFile? result = await FlutterImageCompress.compressAndGetFile(

--- a/lib/widgets/profile/profile_overview_section.dart
+++ b/lib/widgets/profile/profile_overview_section.dart
@@ -10,6 +10,7 @@ import 'package:romrom_fe/screens/my_page/profile_image_crop_screen.dart';
 import 'package:romrom_fe/services/apis/image_api.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
 import 'package:romrom_fe/utils/error_utils.dart';
+import 'package:romrom_fe/utils/image_compressor.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 import 'package:romrom_fe/widgets/common/loading_indicator.dart';
 import 'package:romrom_fe/widgets/user_profile_circular_avatar.dart';
@@ -108,7 +109,8 @@ class _ProfileOverviewSectionState extends State<ProfileOverviewSection> {
       widget.onShowSaveButton?.call();
 
       try {
-        final List<String> urls = await ImageApi().uploadImages([croppedFile]);
+        final XFile compressed = await ImageCompressor.toWebp(croppedFile);
+        final List<String> urls = await ImageApi().uploadImages([compressed]);
         if (mounted) {
           if (urls.isNotEmpty) {
             setState(() => _imageUrl = urls.first);

--- a/lib/widgets/register_input_form.dart
+++ b/lib/widgets/register_input_form.dart
@@ -931,7 +931,7 @@ class _RegisterInputFormState extends State<RegisterInputForm> {
                         if (context.mounted) {
                           CommonSnackBar.show(
                             context: context,
-                            message: '물품 $modeText에 실패했습니다: $e',
+                            message: ErrorUtils.getErrorMessage(e),
                             type: SnackBarType.error,
                           );
                         }

--- a/lib/widgets/register_input_form.dart
+++ b/lib/widgets/register_input_form.dart
@@ -23,6 +23,7 @@ import 'package:romrom_fe/screens/item_register_location_screen.dart';
 import 'package:romrom_fe/services/apis/image_api.dart';
 import 'package:romrom_fe/services/apis/item_api.dart';
 import 'package:romrom_fe/services/location_service.dart';
+import 'package:romrom_fe/utils/image_compressor.dart';
 import 'package:romrom_fe/utils/price_comma_format_utils.dart';
 import 'package:romrom_fe/widgets/common/category_chip.dart';
 import 'package:romrom_fe/exceptions/ugc_violation_exception.dart';
@@ -92,6 +93,10 @@ class _RegisterInputFormState extends State<RegisterInputForm> {
   // 소스 선택 바텀시트~촬영/선택 완료까지 진행 중 가드 (더블탭 방지)
   bool _isPickingSource = false;
   final List<XFile> _newImageFiles = []; // 새로 선택된 로컬 이미지 파일 (아직 업로드 안 됨)
+  // _newImageFiles와 인덱스 1:1로 정렬되는 백그라운드 압축 Future 리스트.
+  // 선택 시 add, 삭제 시 같은 index를 removeAt, 등록 시 index로 수거.
+  // (path를 key로 쓰면 동일 파일 재선택 시 충돌하므로 인덱스 정렬 리스트를 쓴다.)
+  final List<Future<XFile>> _compressing = [];
   final List<String> _existingImageUrls = []; // 수정 모드: 기존 서버 이미지 URL
 
   // 상품사진 갤러리에서 가져오는 함수
@@ -133,6 +138,7 @@ class _RegisterInputFormState extends State<RegisterInputForm> {
           if (!mounted) return;
           setState(() {
             _newImageFiles.add(shot);
+            _compressing.add(ImageCompressor.toWebp(shot));
           });
 
         case ImagePickSource.gallery:
@@ -144,6 +150,7 @@ class _RegisterInputFormState extends State<RegisterInputForm> {
           if (!mounted) return;
           setState(() {
             _newImageFiles.addAll(toAdd);
+            _compressing.addAll(toAdd.map(ImageCompressor.toWebp));
           });
       }
     } catch (e) {
@@ -168,8 +175,10 @@ class _RegisterInputFormState extends State<RegisterInputForm> {
         // 기존 서버 이미지 삭제
         _existingImageUrls.removeAt(index);
       } else {
-        // 새로 추가된 로컬 이미지 삭제
-        _newImageFiles.removeAt(index - existingCount);
+        // 새로 추가된 로컬 이미지 삭제 (압축 리스트도 같은 index 제거 → 결과 버림)
+        final localIndex = index - existingCount;
+        _newImageFiles.removeAt(localIndex);
+        _compressing.removeAt(localIndex);
       }
     });
   }
@@ -230,6 +239,7 @@ class _RegisterInputFormState extends State<RegisterInputForm> {
         );
       }
       _newImageFiles.clear();
+      _compressing.clear();
       _latitude = item?.latitude;
       _longitude = item?.longitude;
       useAiPrice = item?.isAiPredictedPrice ?? false;
@@ -828,12 +838,16 @@ class _RegisterInputFormState extends State<RegisterInputForm> {
                           _isLoading = true;
                         });
 
-                        // 새 로컬 이미지가 있으면 서버에 업로드
+                        // 새 로컬 이미지가 있으면 압축본을 수거해 서버에 업로드
                         List<String> newImageUrls = [];
                         if (_newImageFiles.isNotEmpty) {
-                          newImageUrls = await ImageApi().uploadImages(_newImageFiles);
-                          if (newImageUrls.length != _newImageFiles.length) {
-                            throw Exception('일부 이미지 업로드에 실패했습니다 (${newImageUrls.length}/${_newImageFiles.length})');
+                          // 선택 시 시작한 백그라운드 압축을 순서 보존하여 수거.
+                          // _compressing은 _newImageFiles와 인덱스 1:1이라 그대로 await.
+                          // 보통 이미 완료되어 대기 0, 미완료분만 짧게 대기.
+                          final List<XFile> compressed = await Future.wait(_compressing);
+                          newImageUrls = await ImageApi().uploadImages(compressed);
+                          if (newImageUrls.length != compressed.length) {
+                            throw Exception('일부 이미지 업로드에 실패했습니다 (${newImageUrls.length}/${compressed.length})');
                           }
                         }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1187,10 +1187,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1752,10 +1752,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1187,10 +1187,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1752,10 +1752,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -507,6 +507,54 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_image_compress:
+    dependency: "direct main"
+    description:
+      name: flutter_image_compress
+      sha256: "51d23be39efc2185e72e290042a0da41aed70b14ef97db362a6b5368d0523b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  flutter_image_compress_common:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_common
+      sha256: c5c5d50c15e97dd7dc72ff96bd7077b9f791932f2076c5c5b6c43f2c88607bfb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.6"
+  flutter_image_compress_macos:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_macos
+      sha256: "20019719b71b743aba0ef874ed29c50747461e5e8438980dfa5c2031898f7337"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  flutter_image_compress_ohos:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_ohos
+      sha256: e76b92bbc830ee08f5b05962fc78a532011fcd2041f620b5400a593e96da3f51
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
+  flutter_image_compress_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_platform_interface
+      sha256: "579cb3947fd4309103afe6442a01ca01e1e6f93dc53bb4cbd090e8ce34a41889"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  flutter_image_compress_web:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_web
+      sha256: b9b141ac7c686a2ce7bb9a98176321e1182c9074650e47bb140741a44b6f5a96
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.5"
   flutter_linkify:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   http_parser: ^4.0.2
   in_app_review: ^2.0.9
   image_picker: ^1.1.2
+  flutter_image_compress: ^2.3.0
   intl: ^0.20.2
   json_annotation: ^4.9.0
   kakao_flutter_sdk: ^1.9.7+3

--- a/test/utils/image_compressor_test.dart
+++ b/test/utils/image_compressor_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:romrom_fe/utils/image_compressor.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ImageCompressor.toWebp', () {
+    test('존재하지 않는 파일이면 원본 XFile을 그대로 반환하고 throw하지 않는다', () async {
+      const sourcePath = '/non/existent/path/fake.jpg';
+      final source = XFile(sourcePath);
+
+      final result = await ImageCompressor.toWebp(source);
+
+      expect(result.path, sourcePath);
+    });
+
+    test('상수값이 BE와 동일하다 (가로 1280, Q80)', () {
+      expect(ImageCompressor.targetWidth, 1280);
+      expect(ImageCompressor.quality, 80);
+    });
+  });
+}


### PR DESCRIPTION
## 개요

물품 등록·프로필 이미지를 업로드 전 **기기에서 WebP 압축**(가로 1280, Q80)하여 백엔드 압축 부하·대기시간을 줄인다.

## 변경 사항

- **공통 유틸 `ImageCompressor.toWebp(XFile)`** 추가 (`lib/utils/image_compressor.dart`)
  - WebP / 가로 1280 축소(비율 유지) / Q80 — 현 백엔드 산출물과 동일
  - 압축 실패 시 원본 XFile 그대로 반환 (백엔드 조건부 압축이 안전망)
- **물품 등록** (`register_input_form.dart`): 이미지 선택 즉시 백그라운드 압축 시작, 미리보기는 원본으로 즉시 표시 → 등록 시점엔 보통 압축 완료되어 추가 대기 없음
  - `_newImageFiles`와 인덱스 1:1 정렬되는 `List<Future<XFile>> _compressing` 으로 순서 보존·동일 파일 충돌 방지
  - 삭제 시 같은 index 제거(결과 버림), 등록 시 `Future.wait` 로 수거
- **프로필 이미지** (`profile_overview_section.dart`): 크롭 결과를 업로드 직전 WebP 압축
- 단위 테스트 추가 (`test/utils/image_compressor_test.dart`): 실패 fallback·상수 검증

## 예상 효과

원본의 5~15% 용량 (4MB 사진 → 약 250KB). 업로드·백엔드 처리 시간 대폭 감소.

## 참고

- 설계: `docs/superpowers/specs/2026-05-28-client-side-image-compression-design.md`
- 구현 plan: `docs/superpowers/plans/2026-05-28-client-side-image-compression.md`
- BE 조건부 압축(안전망) 후속: TEAM-ROMROM/RomRom-BE#733

## 관련 이슈

- https://github.com/TEAM-ROMROM/RomRom-FE/issues/887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 상품 등록 및 프로필 이미지 업로드 시 자동 WebP 압축 적용(선택 즉시 백그라운드 압축, 업로드 시 압축본 사용)
  * 업로드 시 원본 순서 보존하며 일괄 수집해 전송

* **문서**
  * 클라이언트 측 이미지 압축 설계 및 작업 계획 문서 추가

* **테스트**
  * 이미지 압축 유틸 동작(실패 시 원본 반환 등) 검증 테스트 추가

* **안정성**
  * 압축 실패 시 원본 사용으로 업로드 신뢰성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEAM-ROMROM/RomRom-FE/pull/888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->