### PR TITLE
20260601 #906 app store 심사 거절 카메라 권한 ux 및 지원 url 수정

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -38,5 +38,16 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+        '$(inherited)',
+        'PERMISSION_CAMERA=1',
+        'PERMISSION_PHOTOS=1',
+        'PERMISSION_LOCATION=1',
+        'PERMISSION_LOCATION_ALWAYS=1',
+        'PERMISSION_LOCATION_WHENINUSE=1',
+        'PERMISSION_NOTIFICATIONS=1',
+      ]
+    end
   end
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -39,14 +39,13 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
     target.build_configurations.each do |config|
-      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
-        '$(inherited)',
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] |= [
         'PERMISSION_CAMERA=1',
         'PERMISSION_PHOTOS=1',
         'PERMISSION_LOCATION=1',
         'PERMISSION_LOCATION_ALWAYS=1',
         'PERMISSION_LOCATION_WHENINUSE=1',
-        'PERMISSION_NOTIFICATIONS=1',
       ]
     end
   end

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -9,7 +9,12 @@
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<string>ko</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>ko</string>
+		<string>en</string>
+	</array>
 	<key>CFBundleDisplayName</key>
 	<string>롬롬</string>
 	<key>CFBundleExecutable</key>

--- a/lib/utils/camera_permission_helper.dart
+++ b/lib/utils/camera_permission_helper.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:romrom_fe/enums/snack_bar_type.dart';
+import 'package:romrom_fe/widgets/common/common_modal.dart';
 import 'package:romrom_fe/widgets/common/common_snack_bar.dart';
 
 /// 카메라 권한을 확보한다.
 ///
 /// - 허용되면 true.
 /// - 거부되면 안내 스낵바를 띄우고 false.
-/// - 영구 거부(다시 묻지 않음)면 안내 스낵바 + 설정 화면 이동 후 false.
+/// - 영구 거부(다시 묻지 않음)면 설정 이동 확인 모달을 띄우고 false.
 ///
 /// 호출 측은 반환값이 false면 촬영을 진행하지 않는다.
 Future<bool> ensureCameraPermission(BuildContext context) async {
@@ -19,9 +20,8 @@ Future<bool> ensureCameraPermission(BuildContext context) async {
 
   if (status.isPermanentlyDenied) {
     if (context.mounted) {
-      CommonSnackBar.show(context: context, message: '카메라 권한이 꺼져 있어요. 설정에서 권한을 허용해주세요.', type: SnackBarType.info);
+      await _showCameraSettingsModal(context);
     }
-    await openAppSettings();
     return false;
   }
 
@@ -32,11 +32,28 @@ Future<bool> ensureCameraPermission(BuildContext context) async {
 
   if (context.mounted) {
     if (result.isPermanentlyDenied) {
-      CommonSnackBar.show(context: context, message: '카메라 권한이 꺼져 있어요. 설정에서 권한을 허용해주세요.', type: SnackBarType.info);
-      await openAppSettings();
+      await _showCameraSettingsModal(context);
     } else {
       CommonSnackBar.show(context: context, message: '카메라 권한이 필요해요.', type: SnackBarType.info);
     }
   }
   return false;
+}
+
+/// 카메라 권한이 영구 거부된 경우 설정 이동 여부를 묻는 모달.
+///
+/// Apple 가이드라인(5.1.1(iv))에 따라 설정 앱으로 자동 이동하지 않고
+/// 사용자가 직접 선택하도록 한다.
+Future<void> _showCameraSettingsModal(BuildContext context) async {
+  await CommonModal.confirm(
+    context: context,
+    message: '카메라 권한이 꺼져 있어요.\n사진 촬영을 위해 설정에서\n카메라 접근을 허용해주세요.',
+    cancelText: '취소',
+    confirmText: '설정 열기',
+    onCancel: () => Navigator.of(context).pop(),
+    onConfirm: () {
+      Navigator.of(context).pop();
+      openAppSettings();
+    },
+  );
 }


### PR DESCRIPTION
#906 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 카메라 권한 영구 거부 시 사용자가 설정 열기를 확인할 수 있는 모달을 추가했습니다.

* **Chores**
  * iOS 앱 로케일을 한국어 기반으로 고정하고 한국어/영어 로케일을 명시했습니다.
  * iOS 권한 전처리 정의 및 권한 관련 빌드 설정을 명시적으로 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->