### PR TITLE
홈 카드 핸드에서 본인 물품 선택 시 우측 물품이 선택됨

### DIFF
--- a/docs/superpowers/plans/2026-06-05-card-hand-hit-test.md
+++ b/docs/superpowers/plans/2026-06-05-card-hand-hit-test.md
@@ -1,0 +1,121 @@
+# 카드 핸드 히트테스트 정밀화 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 카드 핸드에서 부채꼴로 겹친 카드를 터치할 때, 시각적으로 보이는 최상단 카드가 정확히 선택되도록 `_findCardAtPosition()`을 수정한다.
+
+**Architecture:** `lib/widgets/home_tab_card_hand.dart`의 `_findCardAtPosition()` 단일 메서드 내부만 교체한다. (1) 히트테스트 루프 순서를 렌더 순서(낮은 index = 시각적 최상단)와 일치시키고, (2) 터치점을 각 카드의 회전각만큼 역회전한 뒤 카드 사각형 안에 들어오는지 판정한다. 시그니처·호출처·다른 메서드는 변경하지 않는다.
+
+**Tech Stack:** Flutter / Dart, `dart:math` (이미 import됨, `math` 별칭).
+
+**관련 spec:** `docs/superpowers/specs/2026-06-05-card-hand-hit-test-design.md`
+
+---
+
+## File Structure
+
+- Modify: `lib/widgets/home_tab_card_hand.dart:426-440` — `_findCardAtPosition()` 메서드 본문 교체
+
+테스트 파일은 생성하지 않는다. `_findCardAtPosition`은 `private` 메서드이며 `_calculateCardTransform`이 `BuildContext`/`MediaQuery`에 의존해 순수 단위 테스트가 불가능하다. 검증은 실기기 QA로 한다 (spec 4절 참조). 이 프로젝트에는 위젯 단위 테스트 인프라가 없으므로 신규 테스트 도입은 YAGNI.
+
+---
+
+## Task 1: `_findCardAtPosition()` 역회전 히트테스트로 교체
+
+**Files:**
+- Modify: `lib/widgets/home_tab_card_hand.dart:425-440`
+
+- [ ] **Step 1: 기존 메서드 본문을 역회전 판정 로직으로 교체**
+
+`lib/widgets/home_tab_card_hand.dart`의 425~440번 줄(아래 "기존 코드")을 "새 코드"로 정확히 교체한다.
+
+기존 코드:
+
+```dart
+  // 좌표에서 카드 찾기
+  String? _findCardAtPosition(Offset localPosition) {
+    // 왼쪽 카드가 위에 있으므로 (reversed로 렌더링됨)
+    // 역순으로 검사하여 위에 있는 카드부터 확인
+    for (int i = _cards.length - 1; i >= 0; i--) {
+      final transform = _calculateCardTransform(context, i, _cards.length);
+      final cardCenterX = transform['centerX'] as double;
+
+      // 카드 영역 체크 (카드 너비의 절반 범위 내)
+      if ((localPosition.dx - cardCenterX).abs() < _cardWidth / 2) {
+        return _cards[i].itemId;
+      }
+    }
+
+    return null;
+  }
+```
+
+새 코드:
+
+```dart
+  // 좌표에서 카드 찾기
+  // 렌더링은 _cards.reversed로 그려져 index 0이 시각적 최상단(Stack 맨 위)이다.
+  // 따라서 index 0부터(=위에 있는 카드부터) 검사해 첫 매치를 반환해야
+  // 사용자가 보는 최상단 카드가 선택된다.
+  String? _findCardAtPosition(Offset localPosition) {
+    for (int i = 0; i < _cards.length; i++) {
+      final transform = _calculateCardTransform(context, i, _cards.length);
+      final double cardCenterX = transform['centerX'] as double;
+      // _calculateCardTransform은 top(카드 상단)을 주므로 중심 Y는 +height/2
+      final double cardCenterY = (transform['top'] as double) + _cardHeight / 2;
+      // 렌더와 동일한 회전각(tangent + tilt)
+      final double angle = transform['angle'] as double;
+
+      // 터치점을 카드 중심 기준 상대 좌표로
+      final double dx = localPosition.dx - cardCenterX;
+      final double dy = localPosition.dy - cardCenterY;
+
+      // 렌더는 rotateZ(angle)이므로 -angle로 역회전해 카드 로컬 좌표로 변환
+      final double cosA = math.cos(-angle);
+      final double sinA = math.sin(-angle);
+      final double localX = dx * cosA - dy * sinA;
+      final double localY = dx * sinA + dy * cosA;
+
+      // 역회전된 좌표가 카드 사각형 안이면 이 카드가 hit (회전·세로 위치 반영)
+      if (localX.abs() < _cardWidth / 2 && localY.abs() < _cardHeight / 2) {
+        return _cards[i].itemId;
+      }
+    }
+
+    return null;
+  }
+```
+
+- [ ] **Step 2: 포맷 적용**
+
+Run: `source ~/.zshrc && dart format --line-length=120 lib/widgets/home_tab_card_hand.dart`
+Expected: `1 file(s) ... 0 changed` 또는 `1 changed` (변경 시 정상)
+
+- [ ] **Step 3: 린트 분석 (에러 없음 확인)**
+
+Run: `source ~/.zshrc && flutter analyze lib/widgets/home_tab_card_hand.dart`
+Expected: `No issues found!` (해당 파일 관련 error/warning 없음)
+
+- [ ] **Step 4: 커밋하지 않고 대기**
+
+⛔ 자동 커밋 금지 규칙. 사용자가 diff를 확인하고 명시적으로 "커밋해줘"라고 요청할 때까지 `git add`/`git commit`을 실행하지 않는다. 변경 요약만 사용자에게 보고한다.
+
+---
+
+## 실기기 QA 체크리스트 (구현 후 사용자/QA가 수행)
+
+코드로 자동 검증할 수 없으므로 실기기에서 다음을 확인한다 (spec 4절).
+
+- [ ] 부채꼴 겹침 영역에서 각 카드의 **우측 상단**(인접 카드와 겹치는 영역)을 터치 → 보이는(최상단) 카드가 선택되는가
+- [ ] 좌 / 중앙 / 우 카드를 각각 선택 → 의도한 카드가 선택되는가
+- [ ] 카드 1장만 있을 때 정상 선택되는가
+- [ ] 카드를 위로 드래그해 교환 요청 화면 진입 시, 전달되는 `giveItemId`가 선택한 카드와 일치하는가
+- [ ] 겹침 없는 빈 영역 터치 시 아무 카드도 선택/드래그되지 않는가
+
+---
+
+## Self-Review 결과
+
+- **Spec coverage:** spec 2절(순서 정렬 + 역회전 판정) → Task 1 Step 1에서 둘 다 구현. spec 3절 데이터 흐름·angle 부호·카드 중심 Y 계산 모두 새 코드에 반영. spec 4절 검증 → QA 체크리스트로 이관. spec 5절 변경 규모(단일 메서드) 준수.
+- **Placeholder scan:** 없음. 모든 코드 블록이 실제 교체 코드.
+- **Type consistency:** `transform['centerX'|'top'|'angle']`는 모두 `_calculateCardTransform` 반환 맵의 실제 키(spec/원본 코드 확인). `_cardWidth`/`_cardHeight`/`math`는 기존 필드·import. 신규 심볼 도입 없음.

--- a/docs/superpowers/specs/2026-06-05-card-hand-hit-test-design.md
+++ b/docs/superpowers/specs/2026-06-05-card-hand-hit-test-design.md
@@ -1,0 +1,91 @@
+# 카드 핸드 히트테스트 정밀화 설계
+
+- **이슈**: [#854](https://github.com/TEAM-ROMROM/RomRom-FE/issues/854) — [버그][홈] 카드 핸드에서 본인 물품 선택 시 우측 물품이 선택됨
+- **작성일**: 2026-06-05
+- **대상 파일**: `lib/widgets/home_tab_card_hand.dart` (단일 파일)
+
+## 1. 문제
+
+홈탭 하단 카드 핸드에서 부채꼴로 겹친 카드 중 하나를 터치하면, 시각적으로 보이는 카드가 아니라 그 **오른쪽에 배치된 카드**가 선택되어 교환 요청의 `giveItemId`로 전달된다.
+
+근본 원인은 `_findCardAtPosition()` (현재 426번 줄)의 두 가지 결함이다.
+
+### 결함 1 — 렌더 순서와 히트테스트 순서 역전
+
+| 구분 | 코드 위치 | 동작 |
+|------|-----------|------|
+| 렌더링 | `build()` 내 `_cards...reversed.map(...)` (1009번 줄) | index 0이 **마지막에 그려짐 → Stack에서 시각적 최상단** |
+| 히트테스트 | `for (int i = _cards.length - 1; i >= 0; i--)` 첫 매치 반환 (429번 줄) | **가장 높은 index** 카드를 반환 |
+
+렌더는 "낮은 index = 위", 히트테스트는 "높은 index 우선"으로 **정반대**다. 겹침 영역에서 사용자 눈에 보이는 최상단 카드는 낮은 index(왼쪽)인데, 히트테스트는 높은 index(오른쪽)를 골라 "우측 물품 선택" 현상이 발생한다.
+
+### 결함 2 — 회전·세로 위치 무시
+
+```dart
+if ((localPosition.dx - cardCenterX).abs() < _cardWidth / 2) { ... }
+```
+
+`centerX`(수평 거리)만 검사하고 카드의 **회전각(`angle`)·세로 위치(`top`)를 전혀 반영하지 않는다.** 카드는 부채꼴로 회전·tilt 되어 있어 실제 화면상 영역이 단순 수직 띠가 아닌데도, X축 거리만으로 판정하므로 겹침 경계(특히 우측 상단)에서 오판이 발생한다.
+
+## 2. 해결 전략
+
+`_findCardAtPosition()` **단일 메서드의 내부 구현만 교체**한다. 입력(`Offset localPosition`)과 출력(`String? itemId`) 시그니처는 유지하므로 호출처(`_handlePanStart`)와 그 외 모든 코드는 변경 없음. 변경은 이 파일 한 곳에 국한된다.
+
+두 결함을 동시에 해결한다.
+
+1. **순서 정렬**: 루프를 `for (int i = 0; i < _cards.length; i++)`로 바꿔 낮은 index(시각적 최상단)부터 검사하고 첫 매치를 반환.
+2. **회전 반영 (역회전 후 사각형 판정)**: 터치점을 각 카드의 로컬 좌표계로 역변환한 뒤 카드 사각형 안에 들어오는지 판정.
+
+### 왜 역회전 방식인가
+
+렌더링이 `Positioned(left, top)` + `Transform(...rotateZ(angle))`로 카드를 배치한다. 동일한 `angle`/위치로 터치점을 역변환하면 **화면에 실제로 그려진 카드 영역과 수학적으로 100% 일치**한다. `_calculateCardTransform()`이 이미 `centerX`, `top`, `angle`을 제공하므로 새 계산식 없이 기존 값을 그대로 재사용한다.
+
+Flutter 네이티브 히트테스트(카드별 GestureDetector) 방식은 가장 정확하지만 드래그/회전 제스처 전체 구조를 재설계해야 해 이번 버그 범위를 크게 초과하므로 채택하지 않는다.
+
+## 3. 구현 상세
+
+### 데이터 흐름
+
+```
+localPosition (덱 로컬 좌표)
+  → for i = 0 .. length-1            // 낮은 index = 시각적 맨 위부터
+      t = _calculateCardTransform(context, i, _cards.length)
+      카드중심 = (t.centerX, t.top + _cardHeight / 2)
+      Δ = localPosition - 카드중심
+      // -angle 만큼 역회전 (카드 로컬 좌표로 변환)
+      localX = Δx * cos(-angle) - Δy * sin(-angle)
+      localY = Δx * sin(-angle) + Δy * cos(-angle)
+      if |localX| < _cardWidth / 2 && |localY| < _cardHeight / 2:
+          return _cards[i].itemId   // 첫 매치 = 최상단 카드
+  → return null
+```
+
+### 핵심 포인트
+
+- **카드 중심 Y**: `_calculateCardTransform`은 `top`(카드 상단)을 반환하므로 중심은 `top + _cardHeight / 2`. 회전은 렌더링에서 `Transform(alignment: Alignment.center)`로 중심 기준이므로 역회전도 중심 기준으로 맞춘다.
+- **angle 부호**: 렌더가 `rotateZ(angle)`(시계방향 양수)이므로 역변환은 `-angle`. 표준 2D 회전 행렬 사용.
+- **transform의 angle**: `_calculateCardTransform`이 반환하는 `angle`은 `tangent + tilt`로, 실제 렌더에 쓰이는 값과 동일하다. fan/pull/reorder 같은 애니메이션 중간 변형은 히트테스트 대상이 아니다(터치 시작은 정지 상태의 카드 기준).
+
+### 엣지 케이스
+
+| 상황 | 동작 |
+|------|------|
+| 카드 0개 | 루프 미실행 → `null` 반환 (기존과 동일) |
+| 카드 1개 | `tilt = 0`, `angle`만 적용되어 정상 판정 |
+| 겹침 없는 빈 영역 터치 | 매치 없음 → `null` |
+| 두 카드가 동시에 포함하는 점 | 낮은 index(시각적 최상단) 우선 반환 — 의도된 동작 |
+
+## 4. 테스트 / 검증
+
+- `_calculateCardTransform`이 `BuildContext`/`MediaQuery`에 의존하므로 순수 단위 테스트는 어렵고 위젯 테스트 환경이 필요하다.
+- 현실적 검증은 **실기기 QA**: 부채꼴 겹침 영역에서
+  - 각 카드의 **우측 상단**(인접 카드와 겹치는 영역)을 터치 → 보이는 카드가 선택되는지
+  - 좌/중앙/우 카드 각각 선택 정확도
+  - 카드 1장만 있을 때 정상 선택
+  - 드래그로 교환 요청 화면 진입 시 전달되는 `giveItemId`가 선택 카드와 일치하는지
+
+## 5. 변경 규모
+
+- `_findCardAtPosition()` 약 15줄 → 약 20줄 (역회전 계산 추가)
+- 다른 메서드·호출처·구조 변경 없음
+- 신규 의존성 없음 (`dart:math`는 이미 import됨)

--- a/lib/widgets/home_tab_card_hand.dart
+++ b/lib/widgets/home_tab_card_hand.dart
@@ -423,15 +423,33 @@ class _HomeTabCardHandState extends State<HomeTabCardHand> with TickerProviderSt
   }
 
   // 좌표에서 카드 찾기
+  // 렌더링은 _cards.reversed로 그려져 index 0이 시각적 최상단(Stack 맨 위)이다.
+  // 따라서 index 0부터(=위에 있는 카드부터) 검사해 첫 매치를 반환해야
+  // 사용자가 보는 최상단 카드가 선택된다.
+  // 전제: hit-test는 _handlePanStart(터치 시작) 시점에 호출되며, 이때 카드는
+  // 팬/재정렬/pull 애니메이션이 끝난 정적 상태다. 따라서 _calculateCardTransform의
+  // 정적 목표값(보간 전)으로 판정해도 실제 렌더 위치와 일치한다.
   String? _findCardAtPosition(Offset localPosition) {
-    // 왼쪽 카드가 위에 있으므로 (reversed로 렌더링됨)
-    // 역순으로 검사하여 위에 있는 카드부터 확인
-    for (int i = _cards.length - 1; i >= 0; i--) {
+    for (int i = 0; i < _cards.length; i++) {
       final transform = _calculateCardTransform(context, i, _cards.length);
-      final cardCenterX = transform['centerX'] as double;
+      final double cardCenterX = transform['centerX'] as double;
+      // transform['top']은 Positioned.top과 동일 기준점(adjustedTop)이므로 중심 Y는 +height/2
+      final double cardCenterY = (transform['top'] as double) + _cardHeight / 2;
+      // 렌더와 동일한 회전각(tangent + tilt)
+      final double angle = transform['angle'] as double;
 
-      // 카드 영역 체크 (카드 너비의 절반 범위 내)
-      if ((localPosition.dx - cardCenterX).abs() < _cardWidth / 2) {
+      // 터치점을 카드 중심 기준 상대 좌표로
+      final double dx = localPosition.dx - cardCenterX;
+      final double dy = localPosition.dy - cardCenterY;
+
+      // 렌더는 rotateZ(angle)이므로 -angle로 역회전해 카드 로컬 좌표로 변환
+      final double cosA = math.cos(-angle);
+      final double sinA = math.sin(-angle);
+      final double localX = dx * cosA - dy * sinA;
+      final double localY = dx * sinA + dy * cosA;
+
+      // 역회전된 좌표가 카드 사각형 안이면 이 카드가 hit (회전·세로 위치 반영)
+      if (localX.abs() < _cardWidth / 2 && localY.abs() < _cardHeight / 2) {
         return _cards[i].itemId;
       }
     }


### PR DESCRIPTION
## 개요
홈탭 카드 핸드에서 부채꼴로 겹친 카드를 터치할 때, 시각적으로 보이는 카드가 아니라 그 우측에 배치된 카드가 선택되어 교환 요청의 `giveItemId`로 전달되던 버그를 수정했습니다.

## 원인
`lib/widgets/home_tab_card_hand.dart`의 `_findCardAtPosition()`에 두 가지 결함이 있었습니다.

1. **렌더 순서와 히트테스트 순서 역전** — 카드는 `_cards.reversed`로 렌더되어 index 0이 시각적 최상단인데, 히트테스트는 가장 높은 index부터 검사해 첫 매치를 반환 → 겹침 영역에서 우측(높은 index) 카드가 선택됨
2. **회전·세로 위치 무시** — `centerX`(수평 거리)만 검사하고 카드의 회전각·세로 위치를 반영하지 않아, 회전된 카드의 실제 영역과 불일치

## 수정
- 히트테스트 루프를 `i = 0 → length-1` 순서로 변경해 렌더 순서(index 0 = 최상단)와 일치시킴
- 터치점을 각 카드 중심 기준으로 `-angle`만큼 역회전한 뒤 `cardWidth × cardHeight` 사각형 안인지 판정 → 렌더의 `rotateZ(angle)`과 정확히 역대응
- 단일 메서드 내부만 교체 (시그니처·호출처·구조 변경 없음)

## 검증
- spec 준수 / 코드 품질 / 최종 리뷰 통과 (서브에이전트 3단계 리뷰)
- `flutter analyze` → No issues found!
- 실기기 QA 체크리스트는 plan 문서에 정리 (겹침 영역 우측 상단 터치 등)

## 관련 이슈
- https://github.com/TEAM-ROMROM/RomRom-FE/issues/854


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 카드 핸드의 터치 감지 정확도를 개선했습니다. 이제 카드가 겹칠 때 카드의 회전 각도와 수직 위치를 정확히 반영하여 시각적으로 최상단 카드를 올바르게 선택합니다.

* **문서**
  * 터치 감지 기능의 설계 및 구현 계획 문서를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->