### PR TITLE
로그인 화면 우하단 버전 정보 미표시

### DIFF
--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:romrom_fe/enums/login_platforms.dart';
 import 'package:romrom_fe/enums/navigation_types.dart';
 import 'package:romrom_fe/models/app_colors.dart';
@@ -41,6 +42,7 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
   bool _showLoginUI = false;
   bool _loginTransitionStarted = false;
   bool _aborted = false;
+  String _appVersion = '';
 
   @override
   void initState() {
@@ -62,6 +64,17 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
     );
 
     unawaited(_initAndNavigate());
+    unawaited(_loadAppVersion());
+  }
+
+  /// 로그인 UI 우하단에 표시할 앱 버전 로드 (LoginScreen과 동일 구현)
+  Future<void> _loadAppVersion() async {
+    try {
+      final packageInfo = await PackageInfo.fromPlatform();
+      if (mounted) {
+        setState(() => _appVersion = packageInfo.version);
+      }
+    } catch (_) {}
   }
 
   /// 스플래시 초기화 전체 타임아웃 (15초)
@@ -249,36 +262,50 @@ class _SplashScreenState extends State<SplashScreen> with TickerProviderStateMix
             if (_showLoginUI)
               FadeTransition(
                 opacity: _loginUIFadeAnim,
-                child: SafeArea(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      const Spacer(flex: 2),
-                      SizedBox(height: 108.w), // 로고 자리 확보
-                      SizedBox(height: 45.h),
-                      Text(
-                        '손쉬운 물건 교환',
-                        style: CustomTextStyles.p1.copyWith(
-                          color: AppColors.textColorWhite.withValues(alpha: 0.6),
-                          fontWeight: FontWeight.w600,
+                child: Stack(
+                  children: [
+                    SafeArea(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          const Spacer(flex: 2),
+                          SizedBox(height: 108.w), // 로고 자리 확보
+                          SizedBox(height: 45.h),
+                          Text(
+                            '손쉬운 물건 교환',
+                            style: CustomTextStyles.p1.copyWith(
+                              color: AppColors.textColorWhite.withValues(alpha: 0.6),
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          SizedBox(height: 17.h),
+                          SvgPicture.asset('assets/images/login-romrom-text.svg', width: 124.w, height: 17.h),
+                          const Spacer(flex: 3),
+                          Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 24.w),
+                            child: AuthButtonGroup(
+                              buttons: [
+                                LoginPlatforms.kakao,
+                                if (Platform.isIOS) LoginPlatforms.apple,
+                                LoginPlatforms.google,
+                              ].map((platform) => LoginButton(platform: platform)).toList(),
+                            ),
+                          ),
+                          SizedBox(height: 48.h),
+                        ],
+                      ),
+                    ),
+                    // 우하단 버전 정보 (LoginScreen과 동일 — 고정 픽셀 사용, iPad 대응)
+                    if (_appVersion.isNotEmpty)
+                      Positioned(
+                        right: 20,
+                        bottom: 40,
+                        child: Text(
+                          'v$_appVersion',
+                          style: CustomTextStyles.p4.copyWith(color: AppColors.textColorWhite.withValues(alpha: 0.4)),
                         ),
                       ),
-                      SizedBox(height: 17.h),
-                      SvgPicture.asset('assets/images/login-romrom-text.svg', width: 124.w, height: 17.h),
-                      const Spacer(flex: 3),
-                      Padding(
-                        padding: EdgeInsets.symmetric(horizontal: 24.w),
-                        child: AuthButtonGroup(
-                          buttons: [
-                            LoginPlatforms.kakao,
-                            if (Platform.isIOS) LoginPlatforms.apple,
-                            LoginPlatforms.google,
-                          ].map((platform) => LoginButton(platform: platform)).toList(),
-                        ),
-                      ),
-                      SizedBox(height: 48.h),
-                    ],
-                  ),
+                  ],
                 ),
               ),
 


### PR DESCRIPTION
## 📌 관련 이슈

- https://github.com/TEAM-ROMROM/RomRom-FE/issues/915

## 🐛 문제

로그인 화면 우하단에 표시되던 앱 버전 정보(`v1.10.82` 형태)가 보이지 않는 버그.

스플래시 리팩토링 이후 스플래시가 `LoginScreen`으로 교체되지 않고 `SplashScreen` 자체가 로그인 UI를 표시하도록 바뀌면서, 정작 사용자가 보는 화면(`SplashScreen`)에는 버전 정보가 누락되어 있었음. (`LoginScreen` 위젯에는 코드가 살아있으나 렌더링되지 않음)

## 🛠️ 변경 사항

- `package_info_plus` import 추가
- `_appVersion` 상태 필드 + `_loadAppVersion()` 메서드 추가 (`initState`에서 호출)
- `FadeTransition`의 child를 `Stack`으로 감싸 기존 `SafeArea > Column`과 버전 정보 `Positioned`를 함께 배치
  - 로그인 버튼과 동일 타이밍(`_loginUIFadeAnim`, 30~100% 구간)으로 자연스럽게 fade in

## ✅ 검증

- 로고 이동 애니메이션은 별도 `Align` 레이어라 충돌 없음
- `right: 20`, `bottom: 40` 고정 픽셀 사용 → iPad 대응 규칙 준수
- 로딩 단계(로고만 표시)에선 미표시, 로그인 UI 등장 시 함께 fade in

## 📂 변경 파일

- `lib/screens/splash_screen.dart` (+54 / -27)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 스플래시 화면에 앱 버전이 우하단에 표시되도록 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->