### PR TITLE
카카오 firebase-token 요청 오류 시 에러 처리 미흡 : fix : getKakaoFirebaseToken 에러 …

### DIFF
--- a/docs/suh-template/analyze/20260608_20260608_카카오_firebasetoken_오류_에러처리_미흡.md
+++ b/docs/suh-template/analyze/20260608_20260608_카카오_firebasetoken_오류_에러처리_미흡.md
@@ -1,0 +1,192 @@
+# 📊 [#918] 카카오 firebase-token 오류 에러처리 미흡 — 분석 문서
+
+---
+
+## 📊 분석 요약
+
+| 항목 | 내용 |
+|------|------|
+| **프로젝트 타입** | Flutter (iOS / Android) |
+| **주요 기술 스택** | Flutter, Firebase Auth, Kakao SDK, Riverpod |
+| **코드 스타일** | 싱글톤 서비스, typed exception, async/await |
+| **수정 범위** | 단일 함수 (`getKakaoFirebaseToken`) |
+| **영향 범위** | 低 — 기존 catch 블록 재사용, UI 변경 없음 |
+
+---
+
+## 🔍 현재 상태
+
+### 소셜 로그인 에러 처리 흐름 비교
+
+```
+[Google / Apple]
+  logInWithGoogle() / logInWithApple()
+    └─ Firebase signInWithCredential()      ← Firebase 단일 인증
+    └─ romAuthApi.signInWithSocial()        ← 409 → EmailAlreadyRegisteredException ✅
+                                                    SUSPENDED → AccountSuspendedException ✅
+    └─ on AccountSuspendedException → rethrow ✅
+    └─ on EmailAlreadyRegisteredException  → rethrow ✅
+
+[Kakao]
+  loginWithKakaoTalk() / loginWithKakaoAccount()
+    └─ _handleLoginSuccess()
+         └─ _signInWithFirebaseCustomToken()
+              └─ romAuthApi.getKakaoFirebaseToken()  ← ❌ 에러 시 generic Exception만 throw
+              └─ Firebase signInWithCustomToken()
+         └─ romAuthApi.signInWithSocial()            ← 409 / SUSPENDED는 여기서 정상 처리
+    └─ on AccountSuspendedException → rethrow ✅ (but unreachable from getKakaoFirebaseToken)
+    └─ on EmailAlreadyRegisteredException  → rethrow ✅ (but unreachable from getKakaoFirebaseToken)
+    └─ catch (error) → PlatformException check → rethrow ← ❌ generic Exception이 여기로 떨어짐
+```
+
+→ `LoginButton.handleLogin()` 의 `catch (e)` 블록: "로그인에 실패했습니다" 스낵바만 표시
+
+---
+
+### 문제 코드 (`rom_auth_api.dart:229~254`)
+
+```dart
+// 현재 코드 — getKakaoFirebaseToken() else 분기
+} else {
+  final Map<String, dynamic> errorData = jsonDecode(response.body);
+  final String errorCode = errorData['code'] ?? 'UNKNOWN';
+  throw Exception('Firebase Custom Token 발급 실패: $errorCode (${response.statusCode})');
+  //  ↑ 모든 서버 에러를 generic Exception으로 throw
+  //    → loginWithKakaoTalk/loginWithKakaoAccount 의 typed catch 블록을 통과하지 못함
+}
+```
+
+---
+
+### 정상 처리 코드 참고 (`rom_auth_api.dart:123~128`)
+
+```dart
+// signInWithSocial() — 이메일 중복 처리 패턴 (올바른 예시)
+} else if (response.statusCode == 409) {
+  final Map<String, dynamic> errorData = jsonDecode(response.body);
+  final String registeredSocialPlatform = errorData['registeredSocialPlatform'] ?? '';
+  throw EmailAlreadyRegisteredException(registeredSocialPlatform: registeredSocialPlatform);
+}
+// 정지 계정 처리 패턴 (올바른 예시)
+if (authResponse.accountStatus == AccountStatus.suspendedAccount.serverName) {
+  throw AccountSuspendedException(
+    suspendReason: authResponse.suspendReason ?? '',
+    suspendedUntil: authResponse.suspendedUntil ?? '',
+  );
+}
+```
+
+---
+
+## 🎯 구현 목표
+
+`getKakaoFirebaseToken()` 의 else 분기에서:
+1. HTTP 409 (또는 `errorCode == EMAIL_ALREADY_REGISTERED`) → `EmailAlreadyRegisteredException` throw
+2. `errorCode == SUSPENDED_MEMBER` → `AccountSuspendedException` throw
+3. 그 외 → 기존 generic `Exception` 유지
+
+---
+
+## 📝 상세 구현 계획
+
+### 수정 파일 1개
+
+**`lib/services/apis/rom_auth_api.dart`**
+
+- 위치: `getKakaoFirebaseToken()` 메서드 내 else 블록 (line ~246)
+- import 추가 필요:
+  - `package:romrom_fe/exceptions/account_suspended_exception.dart` (미 import 상태)
+  - `package:romrom_fe/exceptions/email_already_registered_exception.dart` (미 import 상태)
+
+#### 변경 전
+```dart
+} else {
+  final Map<String, dynamic> errorData = jsonDecode(response.body);
+  final String errorCode = errorData['code'] ?? 'UNKNOWN';
+  throw Exception('Firebase Custom Token 발급 실패: $errorCode (${response.statusCode})');
+}
+```
+
+#### 변경 후
+```dart
+} else {
+  final Map<String, dynamic> errorData = jsonDecode(response.body);
+  final String errorCode = errorData['code'] ?? 'UNKNOWN';
+
+  if (response.statusCode == 409 || errorCode == 'EMAIL_ALREADY_REGISTERED') {
+    final String registeredSocialPlatform = errorData['registeredSocialPlatform'] ?? '';
+    throw EmailAlreadyRegisteredException(registeredSocialPlatform: registeredSocialPlatform);
+  }
+
+  if (errorCode == 'SUSPENDED_MEMBER') {
+    throw AccountSuspendedException(
+      suspendReason: errorData['suspendReason'] ?? '',
+      suspendedUntil: errorData['suspendedUntil'] ?? '',
+    );
+  }
+
+  throw Exception('Firebase Custom Token 발급 실패: $errorCode (${response.statusCode})');
+}
+```
+
+---
+
+### 변경 필요 없는 파일 (확인 완료)
+
+| 파일 | 이유 |
+|------|------|
+| `kakao_auth_service.dart` | `loginWithKakaoTalk/loginWithKakaoAccount` catch 블록이 이미 typed exception rethrow 처리 중 |
+| `login_button.dart` | `on AccountSuspendedException` / `on EmailAlreadyRegisteredException` catch 블록 이미 올바름 |
+| `google_auth_service.dart` | 변경 없음 (참고용 분석) |
+| `apple_auth_service.dart` | 변경 없음 (참고용 분석) |
+
+---
+
+## ⚠️ 주의사항
+
+### 1. 백엔드 응답 형식 미확인
+
+`/api/auth/kakao/firebase-token` 엔드포인트의 실제 에러 응답 body가 확인되지 않음.
+가정하는 형식:
+```json
+// 이메일 중복 (409)
+{ "code": "EMAIL_ALREADY_REGISTERED", "registeredSocialPlatform": "GOOGLE" }
+
+// 정지 계정
+{ "code": "SUSPENDED_MEMBER", "suspendReason": "부적절한 사용", "suspendedUntil": "2026-12-31" }
+```
+- `?? ''` fallback 으로 처리하므로 필드가 없어도 앱 크래시는 없음
+- 단, `AccountSuspendedScreen` 에 `suspendReason`/`suspendedUntil` 가 빈 문자열로 전달될 수 있음
+
+**권장 액션**: 백엔드에 `/kakao/firebase-token` 오류 응답 필드 명세 확인 요청
+
+### 2. `SUSPENDED_MEMBER` vs `SUSPENDED_ACCOUNT`
+
+`ErrorCode` 열거형 (`lib/enums/error_code.dart:34`) 에는 `SUSPENDED_MEMBER` 코드가 정의됨.
+`signInWithSocial()` 의 정지 계정 처리는 응답 body 내 `accountStatus == 'SUSPENDED_ACCOUNT'` 필드를 확인하는 방식.
+firebase-token 엔드포인트에서 정지 계정을 어떤 방식으로 반환하는지 확인 필요:
+- 에러 코드 방식 (`"code": "SUSPENDED_MEMBER"`)
+- 응답 필드 방식 (`"accountStatus": "SUSPENDED_ACCOUNT"`)
+
+현재 구현에서는 에러 코드 방식으로 처리함 (정상 응답 HTTP 200은 이 분기에 도달하지 않으므로, 에러 방식 가정이 합리적).
+
+---
+
+## 📋 최종 구현 체크리스트
+
+```
+✅ 분석 완료
+□ Task 1: rom_auth_api.dart import 2개 추가
+           └─ account_suspended_exception.dart
+           └─ email_already_registered_exception.dart
+□ Task 2: getKakaoFirebaseToken() else 분기 수정
+           └─ 409 / EMAIL_ALREADY_REGISTERED → EmailAlreadyRegisteredException
+           └─ SUSPENDED_MEMBER → AccountSuspendedException
+□ Task 3: dart format --line-length=120 .
+□ Task 4: flutter analyze
+□ Task 5: 수동 테스트 (이메일 중복 / 정지 계정 케이스)
+```
+
+---
+
+다음 단계: `/implement` 로 구현 진행

--- a/docs/suh-template/issue/20260608_TMP1_버그_로그인_카카오_firebase-token_오류_에러처리_미흡.md
+++ b/docs/suh-template/issue/20260608_TMP1_버그_로그인_카카오_firebase-token_오류_에러처리_미흡.md
@@ -1,0 +1,58 @@
+---
+name: ❗[버그][로그인] 카카오 firebase-token 요청 오류 시 에러 처리 미흡
+description: 카카오 로그인 고유 단계인 /kakao/firebase-token 요청 실패 시 이메일 중복·계정 정지 등 에러를 다른 소셜 로그인과 동일하게 처리하지 못하는 버그
+type: bug
+labels: 작업전
+---
+
+🗒️ 설명
+---
+
+카카오 로그인은 다른 소셜 로그인과 달리 `/api/auth/kakao/firebase-token` 요청을 한 단계 더 거친다.
+이 단계에서 서버가 에러를 반환하면(이메일 중복 409, 정지 계정 등), 구글·애플 로그인과 달리 에러가 `EmailAlreadyRegisteredException` / `AccountSuspendedException` 타입으로 변환되지 않고 일반 `Exception`으로 처리된다.
+
+결과적으로 UI에서 "다른 소셜 플랫폼으로 이미 가입된 이메일입니다"나 "정지된 계정입니다" 다이얼로그가 표시되지 않고, 에러가 핸들링되지 않는다.
+
+- 관련 파일:
+  - `lib/services/kakao_auth_service.dart` — `_signInWithFirebaseCustomToken()`
+  - `lib/services/apis/rom_auth_api.dart` — `getKakaoFirebaseToken()`
+
+🔄 재현 방법
+---
+
+1. 카카오 계정으로 로그인 시도 (구글/애플로 이미 가입된 이메일 계정 사용)
+2. 카카오 로그인 버튼 클릭
+3. 카카오 계정 인증 완료
+4. `/kakao/firebase-token` 요청 단계에서 409 또는 에러 응답 수신
+5. 이메일 중복 안내 모달이 표시되지 않고 에러가 사라지거나 예상치 못한 동작 발생 확인
+
+📸 참고 자료
+---
+
+- 관련 파일:
+  - `lib/services/kakao_auth_service.dart` — `loginWithKakaoTalk()`, `loginWithKakaoAccount()`, `_signInWithFirebaseCustomToken()`
+  - `lib/services/apis/rom_auth_api.dart` — `getKakaoFirebaseToken()`
+  - `lib/exceptions/email_already_registered_exception.dart`
+  - `lib/exceptions/account_suspended_exception.dart`
+  - `lib/widgets/login_button.dart` — 소셜 로그인 공통 에러 처리 위치
+
+✅ 예상 동작
+---
+
+- `/kakao/firebase-token` 요청에서 이메일 중복(409) 에러 발생 시 → `EmailAlreadyRegisteredException` throw → 다른 소셜 로그인과 동일하게 "다른 소셜 플랫폼으로 이미 가입된 이메일" 안내 모달 표시
+- 정지 계정 에러 발생 시 → `AccountSuspendedException` throw → "정지된 계정입니다" 안내 모달 표시
+- 구글·애플 로그인의 에러 처리 흐름과 동일하게 동작해야 한다.
+
+⚙️ 환경 정보
+---
+
+- **OS**: iOS / Android
+- **브라우저**: -
+- **기기**: 전 기기
+
+🙋‍♂️ 담당자
+---
+
+- **백엔드**: 미정
+- **프론트엔드**: 미정
+- **디자인**: -

--- a/docs/suh-template/plan/20260608_20260608_카카오_firebasetoken_오류_에러처리_미흡.md
+++ b/docs/suh-template/plan/20260608_20260608_카카오_firebasetoken_오류_에러처리_미흡.md
@@ -1,0 +1,140 @@
+# 🎯 [#918] 카카오 firebase-token 오류 에러 처리 미흡 — 전략 문서
+
+---
+
+## 1. 요약
+
+카카오 로그인은 다른 소셜 로그인에 없는 `/api/auth/kakao/firebase-token` 단계를 추가로 거친다.
+이 단계에서 서버가 이메일 중복(409) 또는 정지 계정 오류를 반환할 때,
+`getKakaoFirebaseToken()`이 typed exception 대신 일반 `Exception`을 던지기 때문에
+`LoginButton`의 에러 처리 분기(`AccountSuspendedException` / `EmailAlreadyRegisteredException`)가 실행되지 않는다.
+결과적으로 사용자에게 적절한 안내 모달 없이 "로그인에 실패했습니다" 스낵바만 표시된다.
+수정 범위는 `getKakaoFirebaseToken()` 단일 함수로 좁다.
+
+---
+
+## 2. 배경 및 목적
+
+**문제/필요성**
+
+| 소셜 로그인 | 에러 처리 경로 |
+|------------|--------------|
+| Google | `GoogleAuthService` → Firebase `signInWithCredential` → `signInWithSocial` → typed exception |
+| Apple | `AppleAuthService` → Firebase `signInWithCredential` → `signInWithSocial` → typed exception |
+| Kakao | `KakaoAuthService` → **`getKakaoFirebaseToken()`** → Firebase `signInWithCustomToken` → `signInWithSocial` → typed exception |
+
+카카오만 Firebase 커스텀 토큰 발급(`/kakao/firebase-token`) 단계가 추가되며,
+이 단계에서 발생하는 오류가 타입화되지 않아 상위 `on AccountSuspendedException` / `on EmailAlreadyRegisteredException` 블록을 통과하지 못한다.
+
+**목표**
+- `getKakaoFirebaseToken()` 오류 응답 처리를 구글·애플과 동일한 수준으로 맞춘다.
+- 이메일 중복 → `EmailAlreadyRegisteredException` throw
+- 정지 계정 → `AccountSuspendedException` throw
+
+**범위**
+- 포함: `lib/services/apis/rom_auth_api.dart` — `getKakaoFirebaseToken()` 에러 분기 수정
+- 제외: `loginWithKakaoTalk()` / `loginWithKakaoAccount()` catch 블록 (이미 typed exception을 올바르게 처리 중), UI 변경, 백엔드 수정
+
+---
+
+## 3. 요구사항
+
+**필수 (P0)**
+- `/kakao/firebase-token` 응답 코드 `EMAIL_ALREADY_REGISTERED` (HTTP 409) 수신 시 `EmailAlreadyRegisteredException` throw
+- `/kakao/firebase-token` 응답 코드 `SUSPENDED_MEMBER` 수신 시 `AccountSuspendedException` throw
+- 나머지 오류는 기존과 동일하게 일반 `Exception` throw
+
+**중요 (P1)**
+- `EmailAlreadyRegisteredException` 생성 시 `registeredSocialPlatform` 필드를 응답 body에서 추출 (`?? ''` fallback 허용)
+- `AccountSuspendedException` 생성 시 `suspendReason` / `suspendedUntil` 필드를 응답 body에서 추출 (`?? ''` fallback 허용)
+
+**선택 (P2)**
+- 백엔드 응답 형식 확인 후 필드 키 일치 여부 검증 (서버 응답 샘플이 있으면 반영)
+
+---
+
+## 4. 선택한 접근 방식
+
+**방식**: `getKakaoFirebaseToken()` 의 else 분기 내에서 status code / error code로 분기 후 typed exception throw
+
+```
+getKakaoFirebaseToken() 오류 분기:
+  HTTP 409  → EMAIL_ALREADY_REGISTERED → EmailAlreadyRegisteredException
+  errorCode == SUSPENDED_MEMBER         → AccountSuspendedException
+  그 외                                 → Exception (기존 동작 유지)
+```
+
+**이유**
+- 수정 범위가 `getKakaoFirebaseToken()` 단 한 곳으로 최소화됨
+- `loginWithKakaoTalk()` / `loginWithKakaoAccount()` catch 블록은 이미 올바르게 작성되어 있어 그대로 재사용 가능
+- `LoginButton`의 에러 처리 분기도 변경 불필요
+
+**대안: `_signInWithFirebaseCustomToken()` 에서 catch + 재변환**
+- `_signInWithFirebaseCustomToken()` 에서 `catch(error)` → error message 파싱 → typed exception re-throw
+- 단점: 문자열 파싱(취약), 불필요한 레이어 추가 → 채택 안 함
+
+---
+
+## 5. 주요 결정사항
+
+| 결정 | 선택 | 이유 |
+|------|------|------|
+| 수정 위치 | `getKakaoFirebaseToken()` | 오류 응답을 가장 먼저 마주치는 지점 |
+| 이메일 중복 분기 기준 | `response.statusCode == 409` | `signInWithSocial` 에서도 409로 판별 (일관성) |
+| 정지 계정 분기 기준 | `errorCode == 'SUSPENDED_MEMBER'` | `ErrorCode` 열거형에 정의된 서버 코드 사용 |
+| suspend 필드 fallback | `?? ''` | firebase-token 엔드포인트가 상세 필드를 미반환할 가능성 대비 |
+| `signInWithSocial` 수정 여부 | 불필요 | 해당 단계는 이미 올바르게 typed exception 처리 중 |
+
+---
+
+## 6. 고려사항 및 위험요소
+
+**기술적 위험**
+
+| 위험 | 대응 |
+|------|------|
+| `/kakao/firebase-token` 엔드포인트가 `registeredSocialPlatform` / `suspendReason` / `suspendedUntil` 필드를 반환하지 않을 수 있음 | `?? ''` fallback 처리 + 백엔드에 응답 형식 확인 요청 권장 |
+| 정지 계정 시 `AccountSuspendedScreen` 에 빈 문자열이 전달되어 UI 어색할 수 있음 | 백엔드 응답 확인 후 필드 추가 요청 또는 빈 값 허용 여부 결정 |
+| `SUSPENDED_MEMBER` 가 아닌 다른 코드로 정지 계정을 반환하는 경우 누락 | 백엔드 에러 코드 스펙 확인 필수 |
+
+**비즈니스 위험**
+
+| 위험 | 대응 |
+|------|------|
+| 정지 계정이 에러 처리 없이 일반 스낵바만 표시되는 현재 상태가 더 오래 지속되면 UX 신뢰도 저하 | 조기 수정 우선 |
+
+---
+
+## 7. 구현 Task 분해
+
+### Task 1 — 백엔드 응답 형식 확인 (선행 권장)
+
+- `/api/auth/kakao/firebase-token` 에러 응답 시 반환 body 샘플 확인
+  - 이메일 중복: `{ "code": "EMAIL_ALREADY_REGISTERED", "registeredSocialPlatform": "..." }`
+  - 정지 계정: `{ "code": "SUSPENDED_MEMBER", "suspendReason": "...", "suspendedUntil": "..." }`
+- 필드명 불일치 시 수정에 반영
+
+### Task 2 — `getKakaoFirebaseToken()` 에러 분기 수정
+
+- 파일: `lib/services/apis/rom_auth_api.dart`
+- 변경 위치: `getKakaoFirebaseToken()` 내 `else` 블록 (현재 line ~246)
+- 로직:
+  ```
+  if (response.statusCode == 409) → EmailAlreadyRegisteredException
+  else if errorCode == 'SUSPENDED_MEMBER' → AccountSuspendedException
+  else → 기존 Exception (유지)
+  ```
+
+### Task 3 — 수동 검증
+
+- 이미 구글/애플로 가입된 이메일로 카카오 로그인 시도 → "이미 XX 계정으로 가입된 이메일" 모달 표시 확인
+- 정지 계정으로 카카오 로그인 시도 → `AccountSuspendedScreen` 이동 확인 (테스트 계정 필요)
+
+---
+
+## 8. 성공 기준
+
+- [ ] 이메일 중복 계정으로 카카오 로그인 시 → 기존 가입 플랫폼 안내 모달 표시 (구글·애플과 동일 동작)
+- [ ] 정지 계정으로 카카오 로그인 시 → `AccountSuspendedScreen` 이동 (구글·애플과 동일 동작)
+- [ ] 그 외 오류(네트워크 등)는 기존 "로그인에 실패했습니다" 스낵바 유지
+- [ ] `flutter analyze` 통과

--- a/lib/services/apis/rom_auth_api.dart
+++ b/lib/services/apis/rom_auth_api.dart
@@ -245,6 +245,19 @@ class RomAuthApi {
       } else {
         final Map<String, dynamic> errorData = jsonDecode(response.body);
         final String errorCode = errorData['code'] ?? 'UNKNOWN';
+
+        if (response.statusCode == 409 || errorCode == 'EMAIL_ALREADY_REGISTERED') {
+          final String registeredSocialPlatform = errorData['registeredSocialPlatform'] ?? '';
+          throw EmailAlreadyRegisteredException(registeredSocialPlatform: registeredSocialPlatform);
+        }
+
+        if (errorCode == 'SUSPENDED_MEMBER') {
+          throw AccountSuspendedException(
+            suspendReason: errorData['suspendReason'] ?? '',
+            suspendedUntil: errorData['suspendedUntil'] ?? '',
+          );
+        }
+
         throw Exception('Firebase Custom Token 발급 실패: $errorCode (${response.statusCode})');
       }
     } catch (e) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1187,10 +1187,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1752,10 +1752,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1187,10 +1187,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1752,10 +1752,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
#918 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 카카오 로그인 시 이메일 중복 및 계정 정지 오류에 대해 사용자에게 더 명확한 안내 메시지가 표시되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->