### PR TITLE
🚀[기능개선][Debug] 서버 로그 WebSocket onDone 레이스 수정 (리뷰반영, #922)

### DIFF
--- a/lib/debug/server_log_client.dart
+++ b/lib/debug/server_log_client.dart
@@ -64,11 +64,15 @@ class ServerLogClient {
       // 핸드셰이크 헤더에 HMAC 서명 첨부 (BE HmacLogHandshakeInterceptor가 검증)
       final headers = SecuredApiUtils.generateHeaders();
 
-      _webSocket = await WebSocket.connect(_endpoint, headers: headers);
+      final socket = await WebSocket.connect(_endpoint, headers: headers);
+      _webSocket = socket;
       _isConnected = true;
       _addSystemLog('[서버 로그] 연결 성공');
 
-      _socketSubscription = _webSocket!.listen(
+      // onDone에서 멤버 필드(_webSocket) 대신 이 연결의 socket을 직접 참조한다.
+      // 빠른 재연결로 _webSocket이 새 소켓으로 교체된 뒤 늦게 실행되는 onDone이
+      // 엉뚱한 소켓의 closeCode를 읽는 레이스를 방지한다.
+      _socketSubscription = socket.listen(
         _onSocketMessage,
         onError: (error) {
           _addSystemLog('[서버 로그] 스트림 에러: $error');
@@ -77,7 +81,7 @@ class ServerLogClient {
         },
         onDone: () {
           // 서버가 닫은 코드로 구독자 초과(정책 위반) 여부 판별
-          final closeCode = _webSocket?.closeCode;
+          final closeCode = socket.closeCode;
           _isConnected = false;
           if (closeCode == WebSocketStatus.policyViolation) {
             // 최대 동시 접속 수 초과 — 슬롯이 해제될 때까지 더 길게 대기 후 재시도


### PR DESCRIPTION
## 개요
코드 리뷰 반영 후속 수정 (#922).

## 변경
- `ServerLogClient.onDone`: 멤버 필드 `_webSocket` 대신 해당 연결의 지역 `socket`을 직접 참조
  - 빠른 재연결로 `_webSocket`이 새 소켓으로 교체된 뒤 늦게 실행되는 `onDone`이 엉뚱한 소켓의 closeCode를 읽는 레이스 방지

## 검증
- flutter analyze: No issues found
- dart format(120): 통과
