### PR TITLE
🚀[기능개선][Debug] 디버그 로그 AOP 상세 로그 토글 버튼 추가 (#922)

### DIFF
--- a/lib/debug/server_log_client.dart
+++ b/lib/debug/server_log_client.dart
@@ -33,6 +33,11 @@ class ServerLogClient {
   bool _isConnected = false;
   bool _shouldReconnect = false;
   Timer? _reconnectTimer;
+  // AOP 상세 로그(@LogMonitor 등) 수신 토글 — 재연결 시 서버에 다시 통보하기 위해 기억
+  bool _aopEnabled = false;
+
+  /// AOP 상세 로그 토글 상태
+  bool get isAopEnabled => _aopEnabled;
 
   void _onUrlChanged(String _) {
     if (_shouldReconnect) {
@@ -68,6 +73,11 @@ class ServerLogClient {
       _webSocket = socket;
       _isConnected = true;
       _addSystemLog('[서버 로그] 연결 성공');
+
+      // 재연결 시 이전 AOP 토글 상태를 서버에 다시 통보 (서버는 세션별 상태라 새 세션은 기본 OFF)
+      if (_aopEnabled) {
+        _sendAopToggle(true);
+      }
 
       // onDone에서 멤버 필드(_webSocket) 대신 이 연결의 socket을 직접 참조한다.
       // 빠른 재연결로 _webSocket이 새 소켓으로 교체된 뒤 늦게 실행되는 onDone이
@@ -131,8 +141,11 @@ class ServerLogClient {
       final message = json['message'] as String? ?? '';
       final threadName = json['threadName'] as String? ?? '';
       final timestamp = json['timestamp'] as String? ?? '';
+      final isAop = json['source'] == 'AOP';
 
-      final displayMessage = '[$level] $loggerName ($threadName): $message';
+      // AOP 상세 로그는 마커(⟫)로 일반 로그와 구분
+      final prefix = isAop ? '⟫ ' : '';
+      final displayMessage = '$prefix[$level] $loggerName ($threadName): $message';
       DateTime time;
       try {
         time = DateTime.parse(timestamp);
@@ -177,6 +190,22 @@ class ServerLogClient {
     if (_shouldReconnect) {
       _addSystemLog('[서버 로그] 포그라운드 복귀 — 재연결 중...');
       _doConnect();
+    }
+  }
+
+  /// AOP 상세 로그(@LogMonitor 등) 수신 토글.
+  /// 상태를 기억하고 서버에 통보한다 (연결 안 된 경우 다음 연결 성공 시 재전송).
+  void setAopEnabled(bool enabled) {
+    _aopEnabled = enabled;
+    _sendAopToggle(enabled);
+    _addSystemLog('[서버 로그] AOP 상세 로그 ${enabled ? "ON" : "OFF"}');
+  }
+
+  /// 현재 WebSocket으로 토글 명령 전송
+  void _sendAopToggle(bool enabled) {
+    final socket = _webSocket;
+    if (socket != null && _isConnected) {
+      socket.add(jsonEncode({'action': 'toggleAop', 'enabled': enabled}));
     }
   }
 

--- a/lib/debug/widgets/debug_server_log_panel.dart
+++ b/lib/debug/widgets/debug_server_log_panel.dart
@@ -122,6 +122,12 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
     setState(() {});
   }
 
+  // AOP 상세 로그(@LogMonitor 등) 토글 — 켜면 서버가 상세 진단 로그를 흘려보냄 (평소 OFF)
+  void _toggleAop() {
+    _client.setAopEnabled(!_client.isAopEnabled);
+    setState(() {});
+  }
+
   @override
   Widget build(BuildContext context) {
     final screenSize = MediaQuery.of(context).size;
@@ -193,6 +199,12 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
             ),
             const SizedBox(width: 4),
             _titleBarButton(icon: _client.isConnected ? Icons.link : Icons.link_off, onTap: _toggleConnection),
+            // AOP 상세 로그 토글 — 켜지면 주황색으로 강조
+            _titleBarButton(
+              icon: _client.isAopEnabled ? Icons.bug_report : Icons.bug_report_outlined,
+              color: _client.isAopEnabled ? Colors.orangeAccent : null,
+              onTap: _toggleAop,
+            ),
             _titleBarButton(
               icon: _showFilters ? Icons.filter_list : Icons.filter_list_off,
               onTap: () => setState(() => _showFilters = !_showFilters),
@@ -209,12 +221,12 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
     );
   }
 
-  Widget _titleBarButton({required IconData icon, required VoidCallback onTap}) {
+  Widget _titleBarButton({required IconData icon, required VoidCallback onTap, Color? color}) {
     return GestureDetector(
       onTap: onTap,
       child: Padding(
         padding: const EdgeInsets.all(4),
-        child: Icon(icon, color: const Color(0xFFCCCCCC), size: 16),
+        child: Icon(icon, color: color ?? const Color(0xFFCCCCCC), size: 16),
       ),
     );
   }


### PR DESCRIPTION
## 개요
디버그 로그 패널에 AOP 상세 로그(@LogMonitor) 토글 추가 (#922).
BE의 AOP 로그 토글(RomRom-BE #788)에 맞춘 클라이언트 구현.

## 변경
- `ServerLogClient.setAopEnabled`: WebSocket으로 `{action:toggleAop,enabled}` 전송, 상태 기억, 재연결 시 복원
- source=AOP 로그는 `⟫` 마커로 일반 로그와 시각 구분
- 디버그 패널 타이틀바에 토글 버튼 (bug_report 아이콘, ON 시 주황색)

## 검증
- flutter analyze: No issues found / dart format(120): 통과
