### PR TITLE
스타일·네비게이션 규칙 위반 일괄 정리 (TextStyle 55건·Color 39건·MaterialPageRoute 7건)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,6 @@ windows/flutter/generated_plugins.cmake
 
 # codegraph local index
 .codegraph/
+
+# gstack local files
+.gstack/

--- a/docs/suh-template/issue/20260727_936_리팩터링_전역_스타일_네비게이션_규칙_위반_일괄_정리.md
+++ b/docs/suh-template/issue/20260727_936_리팩터링_전역_스타일_네비게이션_규칙_위반_일괄_정리.md
@@ -1,0 +1,32 @@
+📝 현재 문제점
+---
+
+- 2026-07-27 전수 진단(main @ v1.10.105) 결과, CLAUDE.md 절대 규칙(스타일·네비게이션) 위반이 누적되어 있다.
+- **직접 `TextStyle(` 사용 55건** — `CustomTextStyles` 미사용. `lib/debug/` 패널 29건, `lib/widgets/coach_mark/` 9건, `notification_bottom_sheet` 등 실사용 위젯 17건.
+- **직접 `Color(0x` 사용 39건** — `AppColors` 미사용. debug 패널 35건, `request_management_tab_screen` 등 실사용 4건.
+- **`MaterialPageRoute` 직접 사용 7건** — `context.navigateTo()` 규칙 위반. `deep_link_router.dart`(4), `register_tab_screen.dart`(2), `home_feed_item_widget.dart`(1).
+- 방치 시 새 코드가 위반 코드를 복붙해 규칙 이탈이 재생산된다. 대형 파일 분해(#후속)·Riverpod 마이그레이션(#후속) 전에 정리해야 이중 작업이 없다.
+
+🛠️ 해결 방안 / 제안 기능
+---
+
+- **TextStyle 통일**: ① 기존 `CustomTextStyles` 스타일 매핑 → ② `CustomTextStyles.pN.copyWith(...)` 파생 → ③ 3회 이상 반복 패턴만 신규 스타일 추가(debug 전용 스타일 포함). **시각적 결과는 기존과 동일 유지.**
+- **Color 통일**: `AppColors` 동일 값 상수 참조, 없는 값은 기존 명명 규칙(`opacityNN<색상>`/용도명 + 한국어 주석)으로 신규 상수 추가. debug 전용 색상은 별도 주석 블록으로 구분.
+- **네비게이션 통일**: `MaterialPageRoute` 7건을 `context.navigateTo()`로 교체. `common_utils.dart` 내부 구현부는 유지. push 반환값 사용처는 `navigateTo<T>` 반환값으로 동일 처리.
+- 상세 설계: `docs/superpowers/specs/2026-07-27-codebase-quality-improvement-design.md` (서브프로젝트 A)
+
+⚙️ 작업 내용
+---
+
+- [ ] 직접 TextStyle 55건 → CustomTextStyles 매핑/파생/신규 스타일로 교체
+- [ ] 직접 Color 39건 → AppColors 상수 참조로 교체 (필요 상수 신규 추가)
+- [ ] MaterialPageRoute 7건 → context.navigateTo() 교체
+- [ ] `dart format --line-length=120 .` + `flutter analyze` 통과
+- [ ] 잔여 위반 0건 재스캔 검증 (grep 기준 debug 포함 전체)
+
+🙋‍♂️ 담당자
+---
+
+- 백엔드: 이름
+- 프론트엔드: @Cassiiopeia
+- 디자인: 이름

--- a/docs/suh-template/issue/20260727_937_리팩터링_전역_900줄_이상_대형_파일_5개_분해.md
+++ b/docs/suh-template/issue/20260727_937_리팩터링_전역_900줄_이상_대형_파일_5개_분해.md
@@ -1,0 +1,37 @@
+📝 현재 문제점
+---
+
+- 900줄 이상 대형 파일이 5개 존재해 가독성·리뷰·수정 안정성이 떨어진다 (2026-07-27 진단, main @ v1.10.105):
+  1. `lib/screens/item_detail_description_screen.dart` — 1,131줄
+  2. `lib/screens/chat_room_screen.dart` — 1,065줄
+  3. `lib/widgets/home_tab_card_hand.dart` — 1,039줄
+  4. `lib/widgets/register_input_form.dart` — 948줄
+  5. `lib/screens/request_management_tab_screen.dart` — 907줄
+- 파일이 커질수록 한 화면에 UI·상태·헬퍼가 뒤섞여 수정 시 사이드이펙트 위험이 커진다.
+
+🛠️ 해결 방안 / 제안 기능
+---
+
+- **동작 불변 위젯 추출**: private 빌더 메서드/대형 build 블록을 별도 위젯 파일로 이동. 상태 로직(setState·provider 연동)은 건드리지 않고 순수 UI만 추출한다.
+- 파일당 목표 **500줄 이하**, 추출 위젯은 `lib/widgets/<화면명>/` 하위로 그룹화.
+- **파일 1개 = 커밋 1개** 단위로 진행해 리뷰·롤백을 쉽게 한다.
+- 파일별 분해 단위는 구현 plan 단계에서 각 파일을 읽고 확정한다.
+- 선행 이슈(스타일 규칙 정리) 머지 후 진행 — 추출 위젯이 처음부터 규칙 준수 상태가 되도록.
+- 상세 설계: `docs/superpowers/specs/2026-07-27-codebase-quality-improvement-design.md` (서브프로젝트 B)
+
+⚙️ 작업 내용
+---
+
+- [ ] item_detail_description_screen.dart 분해 (1,131줄 → 500줄 이하)
+- [ ] chat_room_screen.dart 분해 (1,065줄 → 500줄 이하)
+- [ ] home_tab_card_hand.dart 분해 (1,039줄 → 500줄 이하)
+- [ ] register_input_form.dart 분해 (948줄 → 500줄 이하)
+- [ ] request_management_tab_screen.dart 분해 (907줄 → 500줄 이하)
+- [ ] 각 파일 분해 후 `dart format` + `flutter analyze` 통과 및 화면 스모크 확인
+
+🙋‍♂️ 담당자
+---
+
+- 백엔드: 이름
+- 프론트엔드: @Cassiiopeia
+- 디자인: 이름

--- a/docs/suh-template/issue/20260727_938_리팩터링_상태관리_Riverpod_중앙화_마이그레이션_확대.md
+++ b/docs/suh-template/issue/20260727_938_리팩터링_상태관리_Riverpod_중앙화_마이그레이션_확대.md
@@ -1,0 +1,33 @@
+📝 현재 문제점
+---
+
+- 이슈 #882에서 공유 도메인 상태를 Riverpod provider 중앙 관리로 전환했지만, 아직 **화면 41개 중 31개가 `services/`를 직접 import**하고 있다 (2026-07-27 진단, main @ v1.10.105).
+- 화면 로컬 1회성 API 호출(신고 제출 등)은 규칙상 허용이지만, **공유 도메인 상태를 만지면서 직접 서비스를 호출하는 화면**은 다른 화면과 상태가 어긋난다 — `MainScreen`이 `IndexedStack`이라 탭이 항상 생존하므로 stale 데이터 함정이 있다.
+
+🛠️ 해결 방안 / 제안 기능
+---
+
+- 31개 화면을 전수 분석해 **공유 도메인 상태를 만지는 화면만 선별**한다 (로컬 1회성 호출은 대상 제외).
+- 선별된 도메인별로 `.claude/instructions/state-management.md` 4-레이어 레시피 적용:
+  repository → `@immutable` state → provider(+test) → 화면 `ref.watch` 구독 전환.
+- 비동기 목록 로딩은 `AsyncNotifier`, optimistic 토글은 동기 `Notifier` + `_inFlight` dedup.
+- mutation은 notifier 메서드로만, 목록 갱신은 서버 재조회 원칙 (클라이언트 수동 removeWhere 금지).
+- 대상 도메인 목록·우선순위는 착수 시점에 분석해 별도 spec으로 확정 후 사용자 승인받고 진행.
+- 선행 이슈(스타일 정리·대형 파일 분해) 머지 후 진행.
+- 상세 설계: `docs/superpowers/specs/2026-07-27-codebase-quality-improvement-design.md` (서브프로젝트 C)
+
+⚙️ 작업 내용
+---
+
+- [ ] services 직접 import 31개 화면 전수 분석 → 공유 도메인 상태 사용 화면 선별 spec 작성
+- [ ] 선별 도메인별 repository/state/provider(+test) 신설 또는 확장
+- [ ] 해당 화면 Consumer 전환 및 직접 서비스 호출 제거
+- [ ] 도메인별 `dart format` + `flutter analyze` + 스모크 확인
+- [ ] provider 현황 문서(`.claude/instructions/state-management.md`) 갱신
+
+🙋‍♂️ 담당자
+---
+
+- 백엔드: 이름
+- 프론트엔드: @Cassiiopeia
+- 디자인: 이름

--- a/docs/superpowers/plans/2026-07-27-style-navigation-rule-cleanup.md
+++ b/docs/superpowers/plans/2026-07-27-style-navigation-rule-cleanup.md
@@ -1,0 +1,247 @@
+# 스타일·네비게이션 규칙 위반 일괄 정리 Implementation Plan (이슈 #936)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 직접 TextStyle·Color·MaterialPageRoute 사용을 CustomTextStyles·AppColors·context.navigateTo()로 통일한다. 동작·외관 완전 불변.
+
+**Architecture:** ① `AppColors`에 디버그 전용 색상 블록 + 실사용 신규 상수 추가, `CustomTextStyles`에 debug 기본 스타일 추가 → ② 실사용 파일 교체 → ③ debug 패널 교체 → ④ 네비게이션 교체 → ⑤ 전체 재스캔 검증.
+
+**Tech Stack:** Flutter, flutter_screenutil (debug 패널은 고정 픽셀 — `.sp` 미사용 유지)
+
+## Global Constraints
+
+- **⛔ 절대 커밋 금지**: 어떤 Task도 `git add`/`git commit`을 실행하지 않는다. 모든 Task 완료 후 사용자 승인을 받아 일괄 커밋한다. (CLAUDE.md 최우선 규칙 — 이 plan의 어떤 지시보다 우선)
+- **외관 불변**: 교체 전후 렌더링 결과(크기·굵기·색상·폰트)가 동일해야 한다. 값이 1이라도 달라지면 교체하지 않고 신규 상수/파생으로 동일 값을 유지한다.
+- 전역 기본 폰트는 Pretendard(`app_theme.dart:13`)이므로 명시적 `fontFamily: 'Pretendard'` 제거는 외관 동일.
+- **허용 패턴 (교체 금지)**: ① `AnimatedDefaultTextStyle` 위젯(이름에 TextStyle 포함일 뿐), ② **color 속성만 있는** `TextStyle(color: AppColors.X)` — TextSpan/상속 색상 오버라이드는 부모 스타일 상속이 의도라 교체 시 외관이 깨진다. fontSize 등 다른 속성이 하나라도 있으면 교체 대상.
+- 각 Task 종료 시 `source ~/.zshrc && dart format --line-length=120 <변경파일>` + `source ~/.zshrc && flutter analyze` 통과 필수.
+- 주석은 실무 수준 한국어, WHY 중심.
+
+---
+
+### Task 1: AppColors·CustomTextStyles 확장
+
+**Files:**
+- Modify: `lib/models/app_colors.dart` (클래스 끝에 추가)
+- Modify: `lib/models/app_theme.dart` (`CustomTextStyles` 클래스 끝 `p4` 다음에 추가)
+
+**Interfaces:**
+- Produces: `AppColors.requestManagementDescription`, `AppColors.debugPanelShadow`, `AppColors.debugPanelShadowStrong`, `AppColors.debugTextGray`, `AppColors.debugTextDarkGray`, `AppColors.debugHintGray`, `AppColors.debugDivider`, `AppColors.debugInputBg`, `AppColors.debugProdGreen`, `AppColors.debugDevOrange`, `CustomTextStyles.debugBase` — Task 2·3이 참조
+
+- [ ] **Step 1: AppColors 상수 추가** — `lib/models/app_colors.dart` 클래스 마지막 상수 뒤에 추가:
+
+```dart
+  // 요청관리 탭 설명 텍스트 (연한 크림색)
+  static const Color requestManagementDescription = Color(0xFFFFFFCC);
+
+  // ===== 디버그 패널 전용 (개발자 도구, 고정 다크 팔레트) =====
+  static const Color debugPanelShadow = Color(0x40000000); // 패널 그림자 25% 검정
+  static const Color debugPanelShadowStrong = Color(0x60000000); // 로그 패널 그림자 37.5% 검정
+  static const Color debugTextGray = Color(0xFFCCCCCC); // 밝은 회색 텍스트·아이콘
+  static const Color debugTextDarkGray = Color(0xFF888888); // 어두운 회색 텍스트·아이콘
+  static const Color debugHintGray = Color(0xFF555555); // 입력 힌트 텍스트
+  static const Color debugDivider = Color(0xFF333333); // 패널 구분선
+  static const Color debugInputBg = Color(0xFF1A1A1A); // 입력 필드 배경
+  static const Color debugProdGreen = Color(0xFF4CAF50); // Prod 연결 상태 표시
+  static const Color debugDevOrange = Color(0xFFFF9800); // Dev 연결 상태 표시
+```
+
+- [ ] **Step 2: CustomTextStyles에 debugBase 추가** — `lib/models/app_theme.dart`의 `p4` 정의 다음에 추가:
+
+```dart
+  /// debug 패널 기본 스타일 : 12px 고정 픽셀 (디버그 오버레이는 화면 스케일 무관하게 고정 크기 사용)
+  static TextStyle debugBase = const TextStyle(
+    fontWeight: FontWeight.w400,
+    fontSize: 12,
+    height: 1,
+    letterSpacing: 0,
+    color: Colors.white,
+  );
+```
+
+`Colors` 사용을 위해 파일 상단 import 확인 (`package:flutter/material.dart` 이미 있음).
+
+- [ ] **Step 3: 검증**
+
+Run: `source ~/.zshrc && dart format --line-length=120 lib/models/app_colors.dart lib/models/app_theme.dart && flutter analyze`
+Expected: `No issues found!`
+
+---
+
+### Task 2: 실사용 파일 3건 교체
+
+**Files:**
+- Modify: `lib/screens/request_management_tab_screen.dart:694,717,732`
+- Modify: `lib/widgets/skeletons/notification_settings_skeleton.dart:21`
+
+**Interfaces:**
+- Consumes: `AppColors.requestManagementDescription` (Task 1)
+
+- [ ] **Step 1: request_management_tab_screen.dart 694행** — '요청 목록' 제목 스타일. `CustomTextStyles.h3`(18sp·w500·height1·흰색)과 값이 동일하므로 교체:
+
+```dart
+// 변경 전
+style: TextStyle(
+  color: AppColors.textColorWhite,
+  fontFamily: 'Pretendard',
+  fontSize: 18.sp,
+  fontWeight: FontWeight.w500,
+  height: 1.0,
+),
+// 변경 후
+style: CustomTextStyles.h3,
+```
+
+`CustomTextStyles`/`app_theme.dart` import 없으면 추가: `import 'package:romrom_fe/models/app_theme.dart';`
+
+- [ ] **Step 2: 같은 파일 717행** — `const Color(0x80FFFFFF)` → `AppColors.opacity50White` (동일 값 0x80FFFFFF).
+
+- [ ] **Step 3: 같은 파일 732행** — 설명 텍스트. `CustomTextStyles.p2`(14sp·w500·height1)에 색만 다르므로 파생:
+
+```dart
+// 변경 전
+style: TextStyle(
+  color: const Color(0xFFFFFFCC),
+  fontFamily: 'Pretendard',
+  fontSize: 14.sp,
+  fontWeight: FontWeight.w500,
+  height: 1.0,
+),
+// 변경 후
+style: CustomTextStyles.p2.copyWith(color: AppColors.requestManagementDescription),
+```
+
+- [ ] **Step 4: notification_settings_skeleton.dart 21행** — `const Color(0xFF34353D)` → `AppColors.secondaryBlack1` (동일 값). import 확인: `import 'package:romrom_fe/models/app_colors.dart';`
+
+- [ ] **Step 5: 검증**
+
+Run: `source ~/.zshrc && dart format --line-length=120 lib/screens/request_management_tab_screen.dart lib/widgets/skeletons/notification_settings_skeleton.dart && flutter analyze`
+Expected: `No issues found!`
+
+---
+
+### Task 3: debug 패널 5개 파일 교체
+
+**Files:**
+- Modify: `lib/debug/widgets/debug_log_panel.dart`
+- Modify: `lib/debug/widgets/debug_server_log_panel.dart`
+- Modify: `lib/debug/widgets/debug_url_panel.dart`
+- Modify: `lib/debug/widgets/debug_menu_panel.dart`
+- Modify: `lib/debug/debug_overlay_manager.dart:252`
+
+**Interfaces:**
+- Consumes: `CustomTextStyles.debugBase`, `AppColors.debug*` (Task 1)
+
+**교체 규칙 (5개 파일 공통, 파일마다 전수 적용):**
+
+색상 — 리터럴을 아래 상수로 기계적 치환 (동일 값 매핑):
+
+| 리터럴 | 교체 |
+|--------|------|
+| `Color(0x40000000)` | `AppColors.debugPanelShadow` |
+| `Color(0x60000000)` | `AppColors.debugPanelShadowStrong` |
+| `Color(0xFFCCCCCC)` | `AppColors.debugTextGray` |
+| `Color(0xFF888888)` | `AppColors.debugTextDarkGray` |
+| `Color(0xFF555555)` | `AppColors.debugHintGray` |
+| `Color(0xFF333333)` | `AppColors.debugDivider` |
+| `Color(0xFF1A1A1A)` | `AppColors.debugInputBg` |
+| `Color(0xFF4CAF50)` | `AppColors.debugProdGreen` |
+| `Color(0xFFFF9800)` | `AppColors.debugDevOrange` |
+
+텍스트 스타일 — `TextStyle(...)`을 `CustomTextStyles.debugBase.copyWith(...)`로 치환. **원본과 결과 속성이 완전 동일해야 한다.** debugBase 기본값(w400·12px·white·height1)과 같은 속성은 copyWith에서 생략, 다른 속성만 명시. 예:
+
+```dart
+// 변경 전 (debug_log_panel.dart:179)
+style: TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w600),
+// 변경 후
+style: CustomTextStyles.debugBase.copyWith(fontSize: 13, fontWeight: FontWeight.w600),
+
+// 변경 전 (debug_log_panel.dart:269)
+style: const TextStyle(color: Color(0xFF888888), fontSize: 10, fontFamily: 'monospace'),
+// 변경 후
+style: CustomTextStyles.debugBase.copyWith(color: AppColors.debugTextDarkGray, fontSize: 10, fontFamily: 'monospace'),
+
+// 변경 전 (debug_menu_panel.dart:76) — 조건부 색상도 동일 패턴
+style: TextStyle(color: item.enabled ? Colors.white : AppColors.secondaryBlack2, fontSize: 14),
+// 변경 후
+style: CustomTextStyles.debugBase.copyWith(color: item.enabled ? Colors.white : AppColors.secondaryBlack2, fontSize: 14),
+```
+
+주의: `const TextStyle(...)`을 copyWith 파생으로 바꾸면 `const`가 깨진다 — 감싸는 위젯의 `const`도 함께 제거해야 컴파일된다 (`flutter analyze`가 잡아줌).
+
+- [ ] **Step 1: debug_log_panel.dart 전수 교체** (TextStyle 9건 + Color 리터럴 13건, 라인: 141,174,179,203,221,224,225,247,269,273,296,298,303,312,317-318,344)
+- [ ] **Step 2: debug_server_log_panel.dart 전수 교체** (동일 구조 파일, 라인: 153,186,191,229,247,250,251,273,295,299,322,324,329,338,343-344,370)
+- [ ] **Step 3: debug_url_panel.dart 전수 교체** (라인: 87,94,96,118,137,145,153,170,178,186,189,213,223,238,245)
+- [ ] **Step 4: debug_menu_panel.dart(47,76,79) + debug_overlay_manager.dart(252) 교체**
+- [ ] **Step 5: import 추가 확인** — 각 파일에 `import 'package:romrom_fe/models/app_theme.dart';`, `import 'package:romrom_fe/models/app_colors.dart';` 필요 시 추가
+- [ ] **Step 6: 검증**
+
+Run: `source ~/.zshrc && dart format --line-length=120 lib/debug && flutter analyze`
+Expected: `No issues found!`
+
+Run: `grep -rn "Color(0x" lib/debug --include="*.dart" | grep -v app_colors; grep -rnE "style: (const )?TextStyle\(" lib/debug --include="*.dart"`
+Expected: 출력 없음
+
+---
+
+### Task 4: MaterialPageRoute 7건 → context.navigateTo()
+
+**Files:**
+- Modify: `lib/utils/deep_link_router.dart:79,113,134,145`
+- Modify: `lib/screens/register_tab_screen.dart:471,488`
+- Modify: `lib/widgets/home_feed_item_widget.dart:196`
+
+**Interfaces:**
+- Consumes: `context.navigateTo({required Widget screen, NavigationTypes type, ...})` — `lib/utils/common_utils.dart`의 확장. 기본 `type: NavigationTypes.push`는 내부에서 iOS=Cupertino/Android=Material 분기하므로 **iOS에서는 전환 애니메이션이 기존 Material→Cupertino로 바뀌는 것이 올바른 동작** (다른 화면 전체와 통일됨).
+
+**공통 교체 패턴** (7건 모두 push + await, 반환값 미사용 → 단순 치환):
+
+```dart
+// 변경 전
+await Navigator.of(context).push(
+  MaterialPageRoute(
+    builder: (_) => SomeScreen(...),
+  ),
+);
+// 변경 후
+await context.navigateTo(screen: SomeScreen(...));
+```
+
+`Navigator.push(context, MaterialPageRoute(...))` 형태도 동일하게 `context.navigateTo(screen: ...)`로.
+
+- [ ] **Step 1: deep_link_router.dart 4건 교체** (79행 ItemDetailDescriptionScreen, 113행 ItemDetailDescriptionScreen, 134행 ChatRoomScreen, 145행 ItemDeletedScreen). import 추가: `import 'package:romrom_fe/utils/common_utils.dart';` (없으면). 더 이상 안 쓰는 `MaterialPageRoute` 관련 import 정리는 analyze가 안내.
+- [ ] **Step 2: register_tab_screen.dart 2건 교체** — `_navigateToItemDetail`(471)·`_navigateToEditItem`(488). `onClose: () { Navigator.pop(context); }` 콜백은 그대로 유지 (pop은 규칙 무관).
+- [ ] **Step 3: home_feed_item_widget.dart 1건 교체** — `Navigator.push<void>` → `context.navigateTo<void>(screen: ...)`.
+- [ ] **Step 4: 검증**
+
+Run: `source ~/.zshrc && dart format --line-length=120 lib/utils/deep_link_router.dart lib/screens/register_tab_screen.dart lib/widgets/home_feed_item_widget.dart && flutter analyze`
+Expected: `No issues found!`
+
+Run: `grep -rn "MaterialPageRoute" lib --include="*.dart" | grep -v common_utils`
+Expected: 출력 없음
+
+---
+
+### Task 5: 전체 재스캔 + 최종 검증
+
+**Files:** 없음 (검증 전용)
+
+- [ ] **Step 1: 위반 재스캔**
+
+```bash
+# 스타일 정의형 TextStyle 잔여 (color-only 오버라이드·AnimatedDefaultTextStyle 제외 후 판독)
+grep -rnE "TextStyle\(" lib --include="*.dart" | grep -v app_theme.dart | grep -v CustomTextStyles | grep -v AnimatedDefaultTextStyle | grep -vE "TextStyle\(color: [A-Za-z.]+\)"
+# 직접 Color 잔여
+grep -rn "Color(0x" lib --include="*.dart" | grep -v app_colors.dart
+# MaterialPageRoute 잔여
+grep -rn "MaterialPageRoute" lib --include="*.dart" | grep -v common_utils
+```
+
+Expected: 1번째는 `_buildSubTextStyle` 선언부(반환 타입) 등 비위반만, 2·3번째는 출력 없음. 잔여 발견 시 해당 Task 규칙대로 추가 교체.
+
+- [ ] **Step 2: 전체 포맷 + 린트 + 기존 테스트**
+
+Run: `source ~/.zshrc && dart format --line-length=120 . && flutter analyze && flutter test`
+Expected: format 변경 없음, `No issues found!`, 기존 테스트 전부 PASS
+
+- [ ] **Step 3: 사용자에게 diff 요약 보고 후 커밋 승인 대기** (자동 커밋 금지)

--- a/docs/superpowers/specs/2026-07-27-codebase-quality-improvement-design.md
+++ b/docs/superpowers/specs/2026-07-27-codebase-quality-improvement-design.md
@@ -1,0 +1,97 @@
+# 코드베이스 전반 품질 개선 로드맵 설계
+
+> 2026-07-27 진단 기반. 서브프로젝트 3개(A→B→C)로 분해해 순차 진행한다.
+> 각 서브프로젝트는 별도 이슈·브랜치·PR로 나간다.
+
+## 진단 요약 (2026-07-27, main @ 2fce92b / v1.10.105)
+
+**정상 항목**: `flutter analyze` 이슈 0건, 이벤트 버스 잔재 없음, GlobalKey 교차호출 없음,
+enum 위치 규칙·AlertDialog 금지·isTablet 규칙 모두 준수.
+
+**개선 대상**:
+
+| 항목 | 규모 | 위험도 |
+|------|------|--------|
+| A. 스타일·네비게이션 규칙 위반 | 직접 TextStyle 55건 + 직접 Color 39건 + MaterialPageRoute 7건 | 낮음 (기계적) |
+| B. 대형 파일 분해 | 900줄 이상 5개 파일 | 중간 (동작 불변 리팩터링) |
+| C. Riverpod 마이그레이션 확대 | services 직접 import 화면 31/41개 중 공유 도메인 화면 선별 | 높음 (구조 변경) |
+
+---
+
+## 서브프로젝트 A — 스타일·네비게이션 규칙 위반 일괄 정리
+
+### 대상 및 처리 원칙
+
+**A1. 직접 `TextStyle(` 55건 → CustomTextStyles 통일**
+
+| 위치 | 건수 | 처리 |
+|------|------|------|
+| `lib/debug/widgets/` 3개 패널 + menu | 29 | debug 전용 반복 패턴은 `CustomTextStyles`에 debug 스타일 신규 추가 후 참조 |
+| `lib/widgets/coach_mark/pages/` 5개 | 9 | 기존 스타일 매핑 또는 `copyWith` 파생 |
+| `notification_bottom_sheet` 등 실사용 위젯 | 17 | 기존 스타일 매핑 또는 `copyWith` 파생 |
+
+- 우선순위: ① 기존 `CustomTextStyles` 스타일 그대로 매핑 → ② `CustomTextStyles.pN.copyWith(...)` 파생
+  → ③ 3회 이상 반복되는 패턴만 신규 스타일 추가
+- 폰트 크기·굵기·색상 등 **시각적 결과는 기존과 동일해야 한다** (동작·외관 불변)
+
+**A2. 직접 `Color(0x` 39건 → AppColors 통일**
+
+- `AppColors` 기존 상수와 동일 값이면 그 상수 참조
+- 없는 값은 기존 명명 규칙(`opacityNN<색상>` / 용도명 + 한국어 주석)으로 신규 상수 추가
+- debug 패널 전용 색상은 `// 디버그 패널 전용` 주석 블록으로 묶어 추가
+
+**A3. `MaterialPageRoute` 직접 사용 7건 → `context.navigateTo()` 교체**
+
+| 파일 | 건수 |
+|------|------|
+| `lib/utils/deep_link_router.dart` | 4 |
+| `lib/screens/register_tab_screen.dart` | 2 |
+| `lib/widgets/home_feed_item_widget.dart` | 1 |
+
+- `lib/utils/common_utils.dart` 내부의 MaterialPageRoute는 `navigateTo` 구현부이므로 유지
+- push 반환값(`await` 결과)을 사용하는 곳은 `navigateTo<T>`의 반환값으로 동일하게 처리
+
+### 검증
+- `dart format --line-length=120 .` + `flutter analyze` 통과
+- 변경 파일이 속한 화면 스모크 확인 (빌드 통과 기준)
+
+---
+
+## 서브프로젝트 B — 대형 파일 5개 분해
+
+### 대상 (진행 순서대로)
+
+1. `lib/screens/item_detail_description_screen.dart` (1,131줄)
+2. `lib/screens/chat_room_screen.dart` (1,065줄)
+3. `lib/widgets/home_tab_card_hand.dart` (1,039줄)
+4. `lib/widgets/register_input_form.dart` (948줄)
+5. `lib/screens/request_management_tab_screen.dart` (907줄)
+
+### 원칙
+- **동작 불변 위젯 추출**: private 빌더 메서드/대형 build 블록을 별도 위젯 파일로 이동
+- 상태 로직(setState·provider 연동)은 건드리지 않는다 — 순수 UI 추출만
+- 파일당 목표 500줄 이하, 추출 위젯은 `lib/widgets/<화면명>/` 하위로 그룹화
+- 파일별 분해 단위는 B의 plan 단계에서 각 파일을 읽고 확정
+- 파일 1개 = 커밋 1개 단위로 진행 (리뷰·롤백 용이)
+
+---
+
+## 서브프로젝트 C — Riverpod 마이그레이션 확대
+
+### 원칙
+- 화면 41개 중 `services/` 직접 import 31개를 분석해 **공유 도메인 상태를 만지는 화면만** 선별
+  (화면 로컬 1회성 API 호출 — 신고 제출 등 — 은 규칙상 허용, 대상 아님)
+- 선별된 도메인별로 `.claude/instructions/state-management.md` 레시피 적용:
+  repository → state → provider(+test) → 화면 구독 전환
+- 비동기 목록 로딩은 `AsyncNotifier`, optimistic 토글은 동기 `Notifier` + `_inFlight` dedup
+- 대상 도메인 목록·우선순위는 C 시작 시점에 분석해 별도 spec으로 확정한다
+
+---
+
+## 진행 흐름
+
+1. 서브프로젝트별 이슈 생성 → 브랜치 분리
+2. A: plan 작성 → 구현 → 커밋(사용자 승인) → PR
+3. A 머지 후 B, B 머지 후 C — 각 단계 시작 전 해당 상세 plan을 사용자 승인 후 진행
+4. A를 먼저 하는 이유: B에서 위젯을 추출하기 전에 스타일 규칙을 정리해두면
+   추출된 위젯이 처음부터 규칙 준수 상태가 되어 이중 작업이 없다

--- a/lib/debug/debug_overlay_manager.dart
+++ b/lib/debug/debug_overlay_manager.dart
@@ -249,7 +249,7 @@ class _DebugButtonWrapperState extends State<_DebugButtonWrapper> {
             color: AppColors.primaryBlack.withValues(alpha: 0.8),
             shape: BoxShape.circle,
             border: Border.all(color: AppColors.primaryYellow, width: 1.5),
-            boxShadow: const [BoxShadow(color: Color(0x40000000), blurRadius: 8, offset: Offset(0, 2))],
+            boxShadow: const [BoxShadow(color: AppColors.debugPanelShadow, blurRadius: 8, offset: Offset(0, 2))],
           ),
           child: const Icon(Icons.bug_report, color: AppColors.primaryYellow, size: 24),
         ),

--- a/lib/debug/widgets/debug_log_panel.dart
+++ b/lib/debug/widgets/debug_log_panel.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:romrom_fe/debug/log_capture.dart';
 import 'package:romrom_fe/models/app_colors.dart';
+import 'package:romrom_fe/models/app_theme.dart';
 
 /// 리사이즈/드래그 가능한 로그 뷰어 패널
 class DebugLogPanel extends StatefulWidget {
@@ -138,7 +139,7 @@ class _DebugLogPanelState extends State<DebugLogPanel> {
             color: AppColors.primaryBlack.withValues(alpha: 0.94),
             borderRadius: BorderRadius.circular(8),
             border: Border.all(color: AppColors.secondaryBlack2, width: 1),
-            boxShadow: const [BoxShadow(color: Color(0x60000000), blurRadius: 16, offset: Offset(0, 4))],
+            boxShadow: const [BoxShadow(color: AppColors.debugPanelShadowStrong, blurRadius: 16, offset: Offset(0, 4))],
           ),
           child: Column(
             children: [
@@ -171,12 +172,12 @@ class _DebugLogPanelState extends State<DebugLogPanel> {
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(
           children: [
-            const Icon(Icons.drag_indicator, color: Color(0xFF888888), size: 16),
+            const Icon(Icons.drag_indicator, color: AppColors.debugTextDarkGray, size: 16),
             const SizedBox(width: 4),
-            const Expanded(
+            Expanded(
               child: Text(
                 '로그 뷰어',
-                style: TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w600),
+                style: CustomTextStyles.debugBase.copyWith(fontSize: 13, fontWeight: FontWeight.w600),
               ),
             ),
             _titleBarButton(
@@ -200,7 +201,7 @@ class _DebugLogPanelState extends State<DebugLogPanel> {
       onTap: onTap,
       child: Padding(
         padding: const EdgeInsets.all(4),
-        child: Icon(icon, color: const Color(0xFFCCCCCC), size: 16),
+        child: Icon(icon, color: AppColors.debugTextGray, size: 16),
       ),
     );
   }
@@ -218,11 +219,11 @@ class _DebugLogPanelState extends State<DebugLogPanel> {
               height: 28,
               child: TextField(
                 controller: _searchController,
-                style: const TextStyle(color: Colors.white, fontSize: 11),
+                style: CustomTextStyles.debugBase.copyWith(fontSize: 11),
                 decoration: InputDecoration(
                   hintText: '검색...',
-                  hintStyle: const TextStyle(color: Color(0xFF888888), fontSize: 11),
-                  prefixIcon: const Icon(Icons.search, size: 14, color: Color(0xFF888888)),
+                  hintStyle: CustomTextStyles.debugBase.copyWith(color: AppColors.debugTextDarkGray, fontSize: 11),
+                  prefixIcon: const Icon(Icons.search, size: 14, color: AppColors.debugTextDarkGray),
                   prefixIconConstraints: const BoxConstraints(minWidth: 28),
                   contentPadding: const EdgeInsets.symmetric(horizontal: 8),
                   filled: true,
@@ -243,8 +244,8 @@ class _DebugLogPanelState extends State<DebugLogPanel> {
 
   Widget _buildLogList() {
     if (_filteredLogs.isEmpty) {
-      return const Center(
-        child: Text('로그 없음', style: TextStyle(color: Color(0xFF888888), fontSize: 12)),
+      return Center(
+        child: Text('로그 없음', style: CustomTextStyles.debugBase.copyWith(color: AppColors.debugTextDarkGray)),
       );
     }
 
@@ -266,11 +267,15 @@ class _DebugLogPanelState extends State<DebugLogPanel> {
               children: [
                 TextSpan(
                   text: '$time ',
-                  style: const TextStyle(color: Color(0xFF888888), fontSize: 10, fontFamily: 'monospace'),
+                  style: CustomTextStyles.debugBase.copyWith(
+                    color: AppColors.debugTextDarkGray,
+                    fontSize: 10,
+                    fontFamily: 'monospace',
+                  ),
                 ),
                 TextSpan(
                   text: log.message,
-                  style: const TextStyle(color: Colors.white, fontSize: 10, fontFamily: 'monospace'),
+                  style: CustomTextStyles.debugBase.copyWith(fontSize: 10, fontFamily: 'monospace'),
                 ),
               ],
             ),
@@ -291,16 +296,19 @@ class _DebugLogPanelState extends State<DebugLogPanel> {
         children: [
           GestureDetector(
             onTap: _clearLogs,
-            child: const Row(
+            child: Row(
               children: [
-                Icon(Icons.delete_outline, size: 14, color: Color(0xFFCCCCCC)),
-                SizedBox(width: 4),
-                Text('클리어', style: TextStyle(color: Color(0xFFCCCCCC), fontSize: 11)),
+                const Icon(Icons.delete_outline, size: 14, color: AppColors.debugTextGray),
+                const SizedBox(width: 4),
+                Text('클리어', style: CustomTextStyles.debugBase.copyWith(color: AppColors.debugTextGray, fontSize: 11)),
               ],
             ),
           ),
           const Spacer(),
-          Text('${_filteredLogs.length}건', style: const TextStyle(color: Color(0xFF888888), fontSize: 11)),
+          Text(
+            '${_filteredLogs.length}건',
+            style: CustomTextStyles.debugBase.copyWith(color: AppColors.debugTextDarkGray, fontSize: 11),
+          ),
           const Spacer(),
           GestureDetector(
             onTap: _copyLogs,
@@ -309,13 +317,13 @@ class _DebugLogPanelState extends State<DebugLogPanel> {
                 Icon(
                   Icons.copy,
                   size: 14,
-                  color: _showCopiedFeedback ? AppColors.primaryYellow : const Color(0xFFCCCCCC),
+                  color: _showCopiedFeedback ? AppColors.primaryYellow : AppColors.debugTextGray,
                 ),
                 const SizedBox(width: 4),
                 Text(
                   _showCopiedFeedback ? '복사됨!' : '복사',
-                  style: TextStyle(
-                    color: _showCopiedFeedback ? AppColors.primaryYellow : const Color(0xFFCCCCCC),
+                  style: CustomTextStyles.debugBase.copyWith(
+                    color: _showCopiedFeedback ? AppColors.primaryYellow : AppColors.debugTextGray,
                     fontSize: 11,
                   ),
                 ),
@@ -341,7 +349,7 @@ class _DebugLogPanelState extends State<DebugLogPanel> {
           width: 20,
           height: 20,
           alignment: Alignment.bottomRight,
-          child: const Icon(Icons.drag_handle, size: 14, color: Color(0xFF888888)),
+          child: const Icon(Icons.drag_handle, size: 14, color: AppColors.debugTextDarkGray),
         ),
       ),
     );

--- a/lib/debug/widgets/debug_menu_panel.dart
+++ b/lib/debug/widgets/debug_menu_panel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:romrom_fe/models/app_colors.dart';
+import 'package:romrom_fe/models/app_theme.dart';
 
 /// 디버그 메뉴 항목 정의
 class DebugMenuItem {
@@ -44,7 +45,7 @@ class DebugMenuPanel extends StatelessWidget {
               color: AppColors.primaryBlack.withValues(alpha: 0.94),
               borderRadius: BorderRadius.circular(12),
               border: Border.all(color: AppColors.secondaryBlack2, width: 1),
-              boxShadow: const [BoxShadow(color: Color(0x40000000), blurRadius: 12, offset: Offset(0, 4))],
+              boxShadow: const [BoxShadow(color: AppColors.debugPanelShadow, blurRadius: 12, offset: Offset(0, 4))],
             ),
             padding: const EdgeInsets.symmetric(vertical: 8),
             child: Column(mainAxisSize: MainAxisSize.min, children: items.map((item) => _buildMenuItem(item)).toList()),
@@ -73,10 +74,14 @@ class DebugMenuPanel extends StatelessWidget {
               Expanded(
                 child: Text(
                   item.label,
-                  style: TextStyle(color: item.enabled ? Colors.white : AppColors.secondaryBlack2, fontSize: 14),
+                  style: CustomTextStyles.debugBase.copyWith(
+                    color: item.enabled ? Colors.white : AppColors.secondaryBlack2,
+                    fontSize: 14,
+                  ),
                 ),
               ),
-              if (!item.enabled) const Text('추후', style: TextStyle(color: AppColors.secondaryBlack2, fontSize: 11)),
+              if (!item.enabled)
+                Text('추후', style: CustomTextStyles.debugBase.copyWith(color: AppColors.secondaryBlack2, fontSize: 11)),
             ],
           ),
         ),

--- a/lib/debug/widgets/debug_server_log_panel.dart
+++ b/lib/debug/widgets/debug_server_log_panel.dart
@@ -6,6 +6,7 @@ import 'package:romrom_fe/debug/debug_overlay_manager.dart';
 import 'package:romrom_fe/debug/log_capture.dart';
 import 'package:romrom_fe/debug/server_log_client.dart';
 import 'package:romrom_fe/models/app_colors.dart';
+import 'package:romrom_fe/models/app_theme.dart';
 
 /// 서버 로그 뷰어 패널 (WebSocket 기반)
 class DebugServerLogPanel extends StatefulWidget {
@@ -150,7 +151,7 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
             color: AppColors.primaryBlack.withValues(alpha: 0.94),
             borderRadius: BorderRadius.circular(8),
             border: Border.all(color: AppColors.secondaryBlack2, width: 1),
-            boxShadow: const [BoxShadow(color: Color(0x60000000), blurRadius: 16, offset: Offset(0, 4))],
+            boxShadow: const [BoxShadow(color: AppColors.debugPanelShadowStrong, blurRadius: 16, offset: Offset(0, 4))],
           ),
           child: Column(
             children: [
@@ -183,12 +184,12 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(
           children: [
-            const Icon(Icons.drag_indicator, color: Color(0xFF888888), size: 16),
+            const Icon(Icons.drag_indicator, color: AppColors.debugTextDarkGray, size: 16),
             const SizedBox(width: 4),
-            const Expanded(
+            Expanded(
               child: Text(
                 '서버 로그',
-                style: TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w600),
+                style: CustomTextStyles.debugBase.copyWith(fontSize: 13, fontWeight: FontWeight.w600),
               ),
             ),
             // 연결 상태 표시
@@ -226,7 +227,7 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
       onTap: onTap,
       child: Padding(
         padding: const EdgeInsets.all(4),
-        child: Icon(icon, color: color ?? const Color(0xFFCCCCCC), size: 16),
+        child: Icon(icon, color: color ?? AppColors.debugTextGray, size: 16),
       ),
     );
   }
@@ -244,11 +245,11 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
               height: 28,
               child: TextField(
                 controller: _searchController,
-                style: const TextStyle(color: Colors.white, fontSize: 11),
+                style: CustomTextStyles.debugBase.copyWith(fontSize: 11),
                 decoration: InputDecoration(
                   hintText: '검색...',
-                  hintStyle: const TextStyle(color: Color(0xFF888888), fontSize: 11),
-                  prefixIcon: const Icon(Icons.search, size: 14, color: Color(0xFF888888)),
+                  hintStyle: CustomTextStyles.debugBase.copyWith(color: AppColors.debugTextDarkGray, fontSize: 11),
+                  prefixIcon: const Icon(Icons.search, size: 14, color: AppColors.debugTextDarkGray),
                   prefixIconConstraints: const BoxConstraints(minWidth: 28),
                   contentPadding: const EdgeInsets.symmetric(horizontal: 8),
                   filled: true,
@@ -269,8 +270,8 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
 
   Widget _buildLogList() {
     if (_filteredLogs.isEmpty) {
-      return const Center(
-        child: Text('서버 로그 없음', style: TextStyle(color: Color(0xFF888888), fontSize: 12)),
+      return Center(
+        child: Text('서버 로그 없음', style: CustomTextStyles.debugBase.copyWith(color: AppColors.debugTextDarkGray)),
       );
     }
 
@@ -292,11 +293,15 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
               children: [
                 TextSpan(
                   text: '$time ',
-                  style: const TextStyle(color: Color(0xFF888888), fontSize: 10, fontFamily: 'monospace'),
+                  style: CustomTextStyles.debugBase.copyWith(
+                    color: AppColors.debugTextDarkGray,
+                    fontSize: 10,
+                    fontFamily: 'monospace',
+                  ),
                 ),
                 TextSpan(
                   text: log.message,
-                  style: const TextStyle(color: Colors.white, fontSize: 10, fontFamily: 'monospace'),
+                  style: CustomTextStyles.debugBase.copyWith(fontSize: 10, fontFamily: 'monospace'),
                 ),
               ],
             ),
@@ -317,16 +322,19 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
         children: [
           GestureDetector(
             onTap: _clearLogs,
-            child: const Row(
+            child: Row(
               children: [
-                Icon(Icons.delete_outline, size: 14, color: Color(0xFFCCCCCC)),
-                SizedBox(width: 4),
-                Text('클리어', style: TextStyle(color: Color(0xFFCCCCCC), fontSize: 11)),
+                const Icon(Icons.delete_outline, size: 14, color: AppColors.debugTextGray),
+                const SizedBox(width: 4),
+                Text('클리어', style: CustomTextStyles.debugBase.copyWith(color: AppColors.debugTextGray, fontSize: 11)),
               ],
             ),
           ),
           const Spacer(),
-          Text('${_filteredLogs.length}건', style: const TextStyle(color: Color(0xFF888888), fontSize: 11)),
+          Text(
+            '${_filteredLogs.length}건',
+            style: CustomTextStyles.debugBase.copyWith(color: AppColors.debugTextDarkGray, fontSize: 11),
+          ),
           const Spacer(),
           GestureDetector(
             onTap: _copyLogs,
@@ -335,13 +343,13 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
                 Icon(
                   Icons.copy,
                   size: 14,
-                  color: _showCopiedFeedback ? AppColors.primaryYellow : const Color(0xFFCCCCCC),
+                  color: _showCopiedFeedback ? AppColors.primaryYellow : AppColors.debugTextGray,
                 ),
                 const SizedBox(width: 4),
                 Text(
                   _showCopiedFeedback ? '복사됨!' : '복사',
-                  style: TextStyle(
-                    color: _showCopiedFeedback ? AppColors.primaryYellow : const Color(0xFFCCCCCC),
+                  style: CustomTextStyles.debugBase.copyWith(
+                    color: _showCopiedFeedback ? AppColors.primaryYellow : AppColors.debugTextGray,
                     fontSize: 11,
                   ),
                 ),
@@ -367,7 +375,7 @@ class _DebugServerLogPanelState extends State<DebugServerLogPanel> {
           width: 20,
           height: 20,
           alignment: Alignment.bottomRight,
-          child: const Icon(Icons.drag_handle, size: 14, color: Color(0xFF888888)),
+          child: const Icon(Icons.drag_handle, size: 14, color: AppColors.debugTextDarkGray),
         ),
       ),
     );

--- a/lib/debug/widgets/debug_url_panel.dart
+++ b/lib/debug/widgets/debug_url_panel.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:romrom_fe/debug/runtime_url_manager.dart';
 import 'package:romrom_fe/enums/navigation_types.dart';
 import 'package:romrom_fe/models/app_colors.dart';
+import 'package:romrom_fe/models/app_theme.dart';
 import 'package:romrom_fe/screens/login_screen.dart';
 import 'package:romrom_fe/services/token_manager.dart';
 import 'package:romrom_fe/utils/common_utils.dart';
@@ -84,16 +85,16 @@ class _DebugUrlPanelState extends State<DebugUrlPanel> {
               color: AppColors.primaryBlack.withValues(alpha: 0.95),
               borderRadius: BorderRadius.circular(12),
               border: Border.all(color: AppColors.secondaryBlack2, width: 1),
-              boxShadow: const [BoxShadow(color: Color(0x40000000), blurRadius: 12, offset: Offset(0, 4))],
+              boxShadow: const [BoxShadow(color: AppColors.debugPanelShadow, blurRadius: 12, offset: Offset(0, 4))],
             ),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 _buildHeader(),
-                const Divider(color: Color(0xFF333333), height: 1),
+                const Divider(color: AppColors.debugDivider, height: 1),
                 _buildCurrentUrl(),
-                const Divider(color: Color(0xFF333333), height: 1),
+                const Divider(color: AppColors.debugDivider, height: 1),
                 _buildInputSection(),
                 const SizedBox(height: 8),
                 _buildResetButton(),
@@ -113,10 +114,7 @@ class _DebugUrlPanelState extends State<DebugUrlPanel> {
         children: [
           const Icon(Icons.dns, color: AppColors.primaryYellow, size: 16),
           const SizedBox(width: 8),
-          const Text(
-            '서버 URL 변경',
-            style: TextStyle(color: Colors.white, fontSize: 14, fontWeight: FontWeight.bold),
-          ),
+          Text('서버 URL 변경', style: CustomTextStyles.debugBase.copyWith(fontSize: 14, fontWeight: FontWeight.bold)),
           const Spacer(),
           GestureDetector(
             onTap: widget.onClose,
@@ -134,7 +132,7 @@ class _DebugUrlPanelState extends State<DebugUrlPanel> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('현재 연결', style: TextStyle(color: AppColors.secondaryBlack2, fontSize: 11)),
+          Text('현재 연결', style: CustomTextStyles.debugBase.copyWith(color: AppColors.secondaryBlack2, fontSize: 11)),
           const SizedBox(height: 4),
           Row(
             children: [
@@ -142,17 +140,13 @@ class _DebugUrlPanelState extends State<DebugUrlPanel> {
                 width: 6,
                 height: 6,
                 decoration: BoxDecoration(
-                  color: isProd ? const Color(0xFF4CAF50) : const Color(0xFFFF9800),
+                  color: isProd ? AppColors.debugProdGreen : AppColors.debugDevOrange,
                   shape: BoxShape.circle,
                 ),
               ),
               const SizedBox(width: 6),
               Expanded(
-                child: Text(
-                  _currentUrl,
-                  style: const TextStyle(color: Colors.white, fontSize: 12),
-                  overflow: TextOverflow.ellipsis,
-                ),
+                child: Text(_currentUrl, style: CustomTextStyles.debugBase, overflow: TextOverflow.ellipsis),
               ),
             ],
           ),
@@ -167,7 +161,10 @@ class _DebugUrlPanelState extends State<DebugUrlPanel> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('PR / Issue 번호 입력', style: TextStyle(color: AppColors.secondaryBlack2, fontSize: 11)),
+          Text(
+            'PR / Issue 번호 입력',
+            style: CustomTextStyles.debugBase.copyWith(color: AppColors.secondaryBlack2, fontSize: 11),
+          ),
           const SizedBox(height: 6),
           Row(
             children: [
@@ -175,7 +172,7 @@ class _DebugUrlPanelState extends State<DebugUrlPanel> {
                 child: Container(
                   height: 36,
                   decoration: BoxDecoration(
-                    color: const Color(0xFF1A1A1A),
+                    color: AppColors.debugInputBg,
                     borderRadius: BorderRadius.circular(6),
                     border: Border.all(color: AppColors.secondaryBlack2, width: 1),
                   ),
@@ -183,11 +180,11 @@ class _DebugUrlPanelState extends State<DebugUrlPanel> {
                     controller: _controller,
                     keyboardType: TextInputType.number,
                     inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                    style: const TextStyle(color: Colors.white, fontSize: 13),
-                    decoration: const InputDecoration(
+                    style: CustomTextStyles.debugBase.copyWith(fontSize: 13),
+                    decoration: InputDecoration(
                       hintText: '예: 582',
-                      hintStyle: TextStyle(color: Color(0xFF555555), fontSize: 13),
-                      contentPadding: EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+                      hintStyle: CustomTextStyles.debugBase.copyWith(color: AppColors.debugHintGray, fontSize: 13),
+                      contentPadding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
                       border: InputBorder.none,
                     ),
                     onSubmitted: (_) => _connect(),
@@ -208,9 +205,13 @@ class _DebugUrlPanelState extends State<DebugUrlPanel> {
                             height: 14,
                             child: CircularProgressIndicator(strokeWidth: 2, color: Colors.black),
                           )
-                        : const Text(
+                        : Text(
                             '연결',
-                            style: TextStyle(color: Colors.black, fontSize: 13, fontWeight: FontWeight.bold),
+                            style: CustomTextStyles.debugBase.copyWith(
+                              color: Colors.black,
+                              fontSize: 13,
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
                   ),
                 ),
@@ -218,9 +219,9 @@ class _DebugUrlPanelState extends State<DebugUrlPanel> {
             ],
           ),
           const SizedBox(height: 4),
-          const Text(
+          Text(
             'http://romrom-pr-{번호}.pr.suhsaechan.kr:8079',
-            style: TextStyle(color: Color(0xFF555555), fontSize: 10),
+            style: CustomTextStyles.debugBase.copyWith(color: AppColors.debugHintGray, fontSize: 10),
           ),
         ],
       ),
@@ -235,14 +236,14 @@ class _DebugUrlPanelState extends State<DebugUrlPanel> {
         child: Container(
           height: 36,
           decoration: BoxDecoration(
-            color: const Color(0xFF1A1A1A),
+            color: AppColors.debugInputBg,
             borderRadius: BorderRadius.circular(6),
             border: Border.all(color: AppColors.secondaryBlack2, width: 1),
           ),
           child: Center(
             child: Text(
               'Prod로 초기화',
-              style: TextStyle(
+              style: CustomTextStyles.debugBase.copyWith(
                 color: RuntimeUrlManager().isUsingProd ? AppColors.secondaryBlack2 : Colors.white,
                 fontSize: 13,
               ),

--- a/lib/models/app_colors.dart
+++ b/lib/models/app_colors.dart
@@ -214,4 +214,18 @@ class AppColors {
   // 완료 버튼 배경 색상
   static const Color completionButtonEnabledBackground = primaryYellow; // 활성화된 완료 버튼 배경색
   static const Color completionButtonDisabledBackground = Color(0xFF61501B); // 비활성화된 완료
+
+  // 요청관리 탭 설명 텍스트 (연한 크림색)
+  static const Color requestManagementDescription = Color(0xFFFFFFCC);
+
+  // ===== 디버그 패널 전용 (개발자 도구, 고정 다크 팔레트) =====
+  static const Color debugPanelShadow = Color(0x40000000); // 패널 그림자 25% 검정
+  static const Color debugPanelShadowStrong = Color(0x60000000); // 로그 패널 그림자 37.5% 검정
+  static const Color debugTextGray = Color(0xFFCCCCCC); // 밝은 회색 텍스트·아이콘
+  static const Color debugTextDarkGray = Color(0xFF888888); // 어두운 회색 텍스트·아이콘
+  static const Color debugHintGray = Color(0xFF555555); // 입력 힌트 텍스트
+  static const Color debugDivider = Color(0xFF333333); // 패널 구분선
+  static const Color debugInputBg = Color(0xFF1A1A1A); // 입력 필드 배경
+  static const Color debugProdGreen = Color(0xFF4CAF50); // Prod 연결 상태 표시
+  static const Color debugDevOrange = Color(0xFFFF9800); // Dev 연결 상태 표시
 }

--- a/lib/models/app_theme.dart
+++ b/lib/models/app_theme.dart
@@ -81,4 +81,7 @@ class CustomTextStyles {
     letterSpacing: 0.sp,
     color: AppColors.textColorWhite,
   );
+
+  /// debug 패널 기본 스타일 : 12px 고정 픽셀 (디버그 오버레이는 화면 스케일 무관하게 고정 크기 사용)
+  static TextStyle debugBase = const TextStyle(fontWeight: FontWeight.w400, fontSize: 12, color: Colors.white);
 }

--- a/lib/screens/register_tab_screen.dart
+++ b/lib/screens/register_tab_screen.dart
@@ -466,32 +466,26 @@ class _RegisterTabScreenState extends ConsumerState<RegisterTabScreen> with Tick
 
   Future<void> _navigateToItemDetail(Item item) async {
     if (item.itemId == null) return;
-    await Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (_) => ItemDetailDescriptionScreen(
-          itemId: item.itemId!,
-          imageSize: Size(MediaQuery.of(context).size.width, 400.h),
-          currentImageIndex: 0,
-          heroTag: 'itemImage_${item.itemId}_0',
-          isMyItem: true,
-          isRequestManagement: false,
-        ),
+    await context.navigateTo(
+      screen: ItemDetailDescriptionScreen(
+        itemId: item.itemId!,
+        imageSize: Size(MediaQuery.of(context).size.width, 400.h),
+        currentImageIndex: 0,
+        heroTag: 'itemImage_${item.itemId}_0',
+        isMyItem: true,
+        isRequestManagement: false,
       ),
     );
     // 상태 변경/삭제 시 myItemsProvider가 notifier 경유로 자동 갱신
   }
 
   Future<void> _navigateToEditItem(Item item) async {
-    await Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (_) => ItemModificationScreen(
-          itemId: item.itemId,
-          onClose: () {
-            Navigator.pop(context);
-          },
-        ),
+    await context.navigateTo(
+      screen: ItemModificationScreen(
+        itemId: item.itemId,
+        onClose: () {
+          Navigator.pop(context);
+        },
       ),
     );
     // 수정 완료 후 myItemsProvider가 notifier 경유로 자동 갱신

--- a/lib/screens/request_management_tab_screen.dart
+++ b/lib/screens/request_management_tab_screen.dart
@@ -689,16 +689,7 @@ class _RequestManagementTabScreenState extends ConsumerState<RequestManagementTa
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               // 제목
-              Text(
-                '요청 목록',
-                style: TextStyle(
-                  color: AppColors.textColorWhite,
-                  fontFamily: 'Pretendard',
-                  fontSize: 18.sp,
-                  fontWeight: FontWeight.w500,
-                  height: 1.0,
-                ),
-              ),
+              Text('요청 목록', style: CustomTextStyles.h3),
               // 정렬 칩 (보더 pill) + 완료 표시 토글
               Row(
                 children: [
@@ -714,7 +705,7 @@ class _RequestManagementTabScreenState extends ConsumerState<RequestManagementTa
                   Text(
                     '완료 포함',
                     style: CustomTextStyles.p3.copyWith(
-                      color: const Color(0x80FFFFFF),
+                      color: AppColors.opacity50White,
                       fontWeight: FontWeight.w400,
                       letterSpacing: -0.5.sp,
                     ),
@@ -727,16 +718,7 @@ class _RequestManagementTabScreenState extends ConsumerState<RequestManagementTa
           ),
           SizedBox(height: 8.h),
           // 설명 텍스트
-          Text(
-            '내 물건에 온 교환 요청이에요',
-            style: TextStyle(
-              color: const Color(0xFFFFFFCC),
-              fontFamily: 'Pretendard',
-              fontSize: 14.sp,
-              fontWeight: FontWeight.w500,
-              height: 1.0,
-            ),
-          ),
+          Text('내 물건에 온 교환 요청이에요', style: CustomTextStyles.p2.copyWith(color: AppColors.requestManagementDescription)),
         ],
       ),
     );

--- a/lib/utils/deep_link_router.dart
+++ b/lib/utils/deep_link_router.dart
@@ -5,6 +5,7 @@ import 'package:romrom_fe/enums/notification_type.dart';
 import 'package:romrom_fe/screens/item_detail_description_screen.dart';
 import 'package:romrom_fe/screens/chat_room_screen.dart';
 import 'package:romrom_fe/screens/item_deleted_screen.dart';
+import 'package:romrom_fe/utils/common_utils.dart';
 
 /// 콜드 스타트 딥링크 대기 데이터 (FCM / app_links 공용)
 ///
@@ -75,16 +76,14 @@ class RomRomDeepLinkRouter {
 
       final imageSize = Size(MediaQuery.of(context).size.width, 400.h);
 
-      await Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (_) => ItemDetailDescriptionScreen(
-            itemId: itemId,
-            imageSize: imageSize,
-            currentImageIndex: 0,
-            heroTag: 'share_item_$itemId',
-            isMyItem: false,
-            isRequestManagement: false,
-          ),
+      await context.navigateTo(
+        screen: ItemDetailDescriptionScreen(
+          itemId: itemId,
+          imageSize: imageSize,
+          currentImageIndex: 0,
+          heroTag: 'share_item_$itemId',
+          isMyItem: false,
+          isRequestManagement: false,
         ),
       );
     }
@@ -109,18 +108,16 @@ class RomRomDeepLinkRouter {
 
           final imageSize = Size(MediaQuery.of(context).size.width, 400.h);
 
-          await Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (_) => ItemDetailDescriptionScreen(
-                itemId: itemId,
-                imageSize: imageSize,
-                currentImageIndex: 0,
-                heroTag: 'deeplink_item_$itemId',
-                isMyItem: isMyItem,
-                isRequestManagement: isRequestManagement,
-                isChatAccessAllowed: isChatAccessAllowed,
-                tradeRequestHistoryId: tradeRequestHistoryId,
-              ),
+          await context.navigateTo(
+            screen: ItemDetailDescriptionScreen(
+              itemId: itemId,
+              imageSize: imageSize,
+              currentImageIndex: 0,
+              heroTag: 'deeplink_item_$itemId',
+              isMyItem: isMyItem,
+              isRequestManagement: isRequestManagement,
+              isChatAccessAllowed: isChatAccessAllowed,
+              tradeRequestHistoryId: tradeRequestHistoryId,
             ),
           );
           return;
@@ -131,7 +128,7 @@ class RomRomDeepLinkRouter {
           final chatRoomId = uri.queryParameters['chatRoomId'];
           if (chatRoomId == null || chatRoomId.isEmpty) return;
 
-          await Navigator.of(context).push(MaterialPageRoute(builder: (_) => ChatRoomScreen(chatRoomId: chatRoomId)));
+          await context.navigateTo(screen: ChatRoomScreen(chatRoomId: chatRoomId));
           return;
         }
 
@@ -141,10 +138,8 @@ class RomRomDeepLinkRouter {
           final itemName = extraData?['itemName'] as String? ?? '';
           final deleteReason = extraData?['deleteReason'] as String? ?? '';
 
-          await Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (_) => ItemDeletedScreen(itemTitle: itemName, deleteReason: deleteReason),
-            ),
+          await context.navigateTo(
+            screen: ItemDeletedScreen(itemTitle: itemName, deleteReason: deleteReason),
           );
           return;
         }

--- a/lib/widgets/home_feed_item_widget.dart
+++ b/lib/widgets/home_feed_item_widget.dart
@@ -191,19 +191,16 @@ class _HomeFeedItemWidgetState extends ConsumerState<HomeFeedItemWidget> {
                       scaleDown: AppPressable.scaleCard,
                       enableRipple: false,
                       onTap: () async {
-                        await Navigator.push<void>(
-                          context,
-                          MaterialPageRoute(
-                            builder: (_) => ItemDetailDescriptionScreen(
-                              itemId: widget.item.itemUuid ?? '',
-                              imageSize: Size(screenWidth, screenWidth),
-                              currentImageIndex: index,
-                              heroTag: 'itemImage_${widget.item.itemUuid ?? widget.item.id}_$index',
-                              homeFeedItem: widget.item,
-                              isMyItem: false,
-                              isRequestManagement: false,
-                              isTradeRequestAllowed: true,
-                            ),
+                        await context.navigateTo<void>(
+                          screen: ItemDetailDescriptionScreen(
+                            itemId: widget.item.itemUuid ?? '',
+                            imageSize: Size(screenWidth, screenWidth),
+                            currentImageIndex: index,
+                            heroTag: 'itemImage_${widget.item.itemUuid ?? widget.item.id}_$index',
+                            homeFeedItem: widget.item,
+                            isMyItem: false,
+                            isRequestManagement: false,
+                            isTradeRequestAllowed: true,
                           ),
                         );
                         // 캐시(itemLikeProvider)로 좋아요 상태가 자동 전파됨

--- a/lib/widgets/skeletons/notification_settings_skeleton.dart
+++ b/lib/widgets/skeletons/notification_settings_skeleton.dart
@@ -18,7 +18,7 @@ class NotificationSettingsSkeleton extends StatelessWidget {
 
   Widget _buildGroup(double width, int rowCount) {
     return Container(
-      decoration: BoxDecoration(color: const Color(0xFF34353D), borderRadius: BorderRadius.circular(10)),
+      decoration: BoxDecoration(color: AppColors.secondaryBlack1, borderRadius: BorderRadius.circular(10)),
       child: Column(children: List.generate(rowCount, (i) => _buildRow(width, i, rowCount))),
     );
   }


### PR DESCRIPTION
## 개요

코드베이스 전수 진단(2026-07-27)에서 발견된 스타일·네비게이션 절대 규칙 위반을 일괄 정리합니다. **동작·외관 완전 불변 리팩터링**입니다.

## 관련 이슈

- https://github.com/TEAM-ROMROM/RomRom-FE/issues/936

## 주요 변경

### 1. 직접 `Color(0x...)` 39건 → `AppColors` 통일 (잔여 0건)
- 동일 값 기존 상수 참조: `opacity50White`, `secondaryBlack1`
- 신규 상수 추가: `requestManagementDescription`(0xFFFFFFCC), 디버그 전용 9종(`debugPanelShadow`, `debugTextGray`, `debugProdGreen` 등)

### 2. 스타일 정의형 `TextStyle(...)` → `CustomTextStyles` 통일
- `request_management_tab_screen`: 제목 → `CustomTextStyles.h3`, 설명 → `p2.copyWith(...)` (수치 동일 매핑)
- 디버그 패널 4종 + 오버레이: 신규 `CustomTextStyles.debugBase`(12px 고정 픽셀) 파생으로 통일
- **허용 패턴 유지**: color만 오버라이드하는 `TextStyle(color:)`(TextSpan 상속용)·`AnimatedDefaultTextStyle`은 외관 보존을 위해 유지

### 3. `MaterialPageRoute` 직접 사용 7건 → `context.navigateTo()` (잔여 0건)
- `deep_link_router.dart` 4건, `register_tab_screen.dart` 2건, `home_feed_item_widget.dart` 1건
- iOS 전환이 Cupertino로 통일됨 (앱 전체 네비게이션과 동일 동작)

### 4. 문서
- 코드베이스 품질 개선 로드맵 spec (서브프로젝트 A→B #937→C #938) + 본 작업 plan + 이슈 md 3건

## 검증

- `flutter analyze` 이슈 0건 / `dart format` 변경 없음 / `flutter test` 43/43 통과
- 위반 재스캔: TextStyle 정의형·Color 리터럴·MaterialPageRoute 잔여 모두 0건
- 서브에이전트 태스크별 리뷰 4회 + 최종 전체 리뷰 1회 통과 (최종 리뷰에서 debugBase의 height/letterSpacing 강제로 인한 로그 줄간격 회귀를 발견·수정)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 디버그 패널과 요청관리 화면의 색상·텍스트 스타일을 일관된 디자인 기준으로 정리했습니다.
  * 디버그 로그, 서버 로그, URL 패널의 가독성과 상태 표시를 개선했습니다.
  * 알림 설정 스켈레톤의 배경색 표현을 통일했습니다.

* **사용성 개선**
  * 주요 화면 전환과 딥링크 이동의 동작 및 애니메이션 일관성을 높였습니다.

* **문서화**
  * 스타일·네비게이션 정리, 대형 파일 분해, 상태관리 개선을 위한 작업 계획과 로드맵을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->